### PR TITLE
ZCS-1660 message count and message chart volume show nothing

### DIFF
--- a/WebRoot/js/zimbraAdmin/statistics/view/ZaGlobalAdvancedStatsPage.js
+++ b/WebRoot/js/zimbraAdmin/statistics/view/ZaGlobalAdvancedStatsPage.js
@@ -192,7 +192,9 @@ ZaGlobalAdvancedStatsPage.plotGlobalQuickChart = function (id, group, columns, c
                 for (var i = 0; i < timeStampLength; i++) {
                     var valuesSumAtTs = 0;
                     for (var j = 0; j < hostNameLen; j++) {
-                        if (hostname[j].stats[0].values[i] && hostname[j].stats[0].values[i].stat[0]) {
+                        if (hostname[j].stats && hostname[j].stats.length > 0 && 
+                        	hostname[j].stats[0].values && hostname[j].stats[0].values.length > 0 && hostname[j].stats[0].values[i] &&
+                        	hostname[j].stats[0].values[i].stat && hostname[j].stats[0].values[i].stat.length > 0 && hostname[j].stats[0].values[i].stat[0]) {
                             valuesSumAtTs = valuesSumAtTs + parseFloat(hostname[j].stats[0].values[i].stat[0].value);
                         }
                     }


### PR DESCRIPTION
- fix issue where message volume and chart are not getting generated for multinode environment
- check if object exists before using it

Testing notes:
1) check with customer data
- copied rrd files from ticket to /opt/zimbra/logger/db/data
- restart mail server
- check if charts are generated in admin console

2) check with own server data
- revert back rrd files to earlier ones from /opt/zimbra/logger/db/data
- restart mail server
- check if charts are generated in admin console