### PR TITLE
ZCS-1638 New DL : direct member of field always shows 'Loading' text

### DIFF
--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountMemberOfListView.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountMemberOfListView.js
@@ -750,21 +750,9 @@ ZaAccountMemberOfListView.prototype._setNoResultsHtml = function() {
 	var	div = document.createElement("div");
 	var msg = "";
 	if (this.getCurrentListId().indexOf(ZaAccount.A2_indirectMemberList) >= 0) {
-		var instance = this.parent && this.parent.getInstance();
-		if (instance && instance.memberOfLoaded) {
-			msg = ZaMsg.Account_Group_NoInDirectMember;
-		}
-		else {
-			msg = ZaMsg.MSG_HomeLoading;
-		}
+		msg = ZaMsg.Account_Group_NoInDirectMember;
 	}else if (this.getCurrentListId().indexOf(ZaAccount.A2_directMemberList) >= 0){
-		var instance = this.parent && this.parent.getInstance();
-		if (instance && instance.memberOfLoaded) {
-			msg = ZaMsg.Account_Group_NoDirectMember;
-		}
-		else {
-			msg = ZaMsg.MSG_HomeLoading;
-		}
+		msg = ZaMsg.Account_Group_NoDirectMember;
 	}
 	
 	buffer.append(


### PR DESCRIPTION
Issue: The new Dl dialog shows “Loading” for direct/indirect member list view.
Expected: As its a case of new Dl, there would be nothing to load and thus should be empty widget without a loading text.

Changeset:
*  ZaAccountMemberOfListView.js: Setting the msg variable values as empty string instead of “Loading”.