### PR TITLE
ZCS-1666 C - Bug 107948 - Persistent XSS - mail addrs [CWE-79]

### DIFF
--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
@@ -365,6 +365,8 @@ function (ev) {
     var arr = this.widget.getSelection();
     if(arr && arr.length) {
         arr.sort();
+        //the selection values are HTML encoded, need to decode them before saving to cache.
+        arr =  AjxUtil.htmlDecode(arr);
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_alias_selection_cache, arr);
     } else {
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_alias_selection_cache, null);
@@ -2847,7 +2849,8 @@ textFieldCssClass:"admin_xform_number_input"}
                             items :[
                                 {ref:ZaAccount.A_zimbraMailAlias, type:_DWT_LIST_, height:"200", width:"350px",
                                     forceUpdate: true, preserveSelection:false, multiselect:true,cssClass: "DLSource",
-                                    headerList:null,onSelection:ZaAccountXFormView.aliasSelectionListener
+                                    headerList:null,onSelection:ZaAccountXFormView.aliasSelectionListener,
+                                    getDisplayValue: AjxUtil.htmlEncode
                                 },
                                 {type:_GROUP_, numCols:5, width:"350px", colSizes:["100px","auto","100px","auto","100px"],
                                     cssStyle:"margin:10px;padding-bottom:0;",


### PR DESCRIPTION
ZCS-1666 C - Bug 107948 - Persistent XSS - mail addrs [CWE-79] 

Issue: XSS vulnerability in Admin Console account alias section.
Fix: HTML encoding the alias values at display level.

Changeset:
* ZaAccountXFormView.js:
  * Adding getDisplayValue() definition for aliases tab to set the HTML encoded values on ui.
  * ZaAccountXFormView::aliasSelectionListener(): HTML decoding the aliases display values so that the cached account level values are not saved as HTML encoded.