### PR TITLE
ZCS-1667 XSS Issues

### DIFF
--- a/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
+++ b/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
@@ -1110,15 +1110,18 @@ function() {
 
 ZaZimbraAdmin.prototype.updateHistory =
 function(historyObject, isAddHistory) {
-    if(isAddHistory)
+    if(isAddHistory) {
         this._historyMgr.addHistory(historyObject);
+    }
 
-    if (historyObject.displayName)
+    if (historyObject.displayName) {
+        // Don't html encode display name as display name returned from ZaTreeItem is already encoded
         this._header.setText(historyObject);
+    }
 
-    if (historyObject.path)
+    if (historyObject.path) {
         this._currentAppBar.setText(historyObject.path);
-
+    }
 }
 
 ZaZimbraAdmin.prototype.refreshHistoryTreeByDelete = function(items) {

--- a/WebRoot/js/zimbraAdmin/accounts/controller/ZaAccountListController.js
+++ b/WebRoot/js/zimbraAdmin/accounts/controller/ZaAccountListController.js
@@ -567,10 +567,10 @@ function(ev) {
 		item.loadEffectiveRights("id", item.id, false);
 		this._chngPwdDlg.registerCallback(DwtDialog.OK_BUTTON, ZaAccountListController._changePwdOKCallback, this, item);	
 		if (item.name != undefined && item.name.length > 80) {
-                        this._chngPwdDlg.setTitle(ZaMsg.CHNP_Title + " (" + item.name.substring(1,80) + "..." + ")");
+                        this._chngPwdDlg.setTitle(ZaMsg.CHNP_Title + " (" + AjxStringUtil.htmlEncode(item.name.substring(1,80)) + "..." + ")");
                 } else {
                       if (item.name != undefined) {
-                        this._chngPwdDlg.setTitle(ZaMsg.CHNP_Title + " (" + item.name + ")");
+                        this._chngPwdDlg.setTitle(ZaMsg.CHNP_Title + " (" + AjxStringUtil.htmlEncode(item.name) + ")");
                       } else {
                         this._chngPwdDlg.setTitle(ZaMsg.CHNP_Title);
                       }
@@ -904,37 +904,41 @@ function () {
 
 ZaAccountListController.getDlMsgFromList =
 function (listArr) {
-		var dlgMsg =  "<br><ul>";
-		var i=0;
-		for(var key in listArr) {
-			if(i > 19) {
-				dlgMsg += "<li>...</li>";
-				break;
-			}
-			dlgMsg += "<li>";
-			var szAccName = listArr[key].attrs[ZaAccount.A_displayname] ? AjxStringUtil.htmlEncode(listArr[key].attrs[ZaAccount.A_displayname]) : listArr[key].name;
-            if(szAccName.length > 50) {
-                var beginIx = 0;
-                var endIx = 50;
-				do {
-                    if (endIx >= szAccName.length) {
-                        dlgMsg +=  szAccName.slice(beginIx);     
-                    } else {
-                        dlgMsg +=  szAccName.slice(beginIx, endIx);
-                    }
-					beginIx = endIx;
-					endIx += 50 ;
-                    
-					dlgMsg +=  "<br />";	
-				} while (beginIx < szAccName.length) ;
-			} else {
-				dlgMsg += szAccName;
-			}
-			dlgMsg += "</li>";
-			i++;
+	var dlgMsg = "<br><ul>";
+	var i=0;
+
+	for(var key in listArr) {
+		if(i > 19) {
+			dlgMsg += "<li>...</li>";
+			break;
 		}
-		dlgMsg += "</ul>";	
-		return dlgMsg ;
+
+		dlgMsg += "<li>";
+		var szAccName = listArr[key].attrs[ZaAccount.A_displayname] ? listArr[key].attrs[ZaAccount.A_displayname] : listArr[key].name;
+		if(szAccName.length > 50) {
+			var beginIx = 0;
+			var endIx = 50;
+			do {
+				if (endIx >= szAccName.length) {
+					dlgMsg += AjxStringUtil.htmlEncode(szAccName.slice(beginIx));
+				} else {
+					dlgMsg += AjxStringUtil.htmlEncode(szAccName.slice(beginIx, endIx));
+				}
+				beginIx = endIx;
+				endIx += 50 ;
+
+				dlgMsg +=  "<br />";	
+			} while (beginIx < szAccName.length) ;
+		} else {
+			dlgMsg += AjxStringUtil.htmlEncode(szAccName);
+		}
+
+		dlgMsg += "</li>";
+		i++;
+	}
+
+	dlgMsg += "</ul>";
+	return dlgMsg;
 }
 
 

--- a/WebRoot/js/zimbraAdmin/accounts/view/DeleteAcctsPgrsDlg.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/DeleteAcctsPgrsDlg.js
@@ -140,7 +140,7 @@ function(evt) {
 		this._currentIndex=0;
 		var obj = new Object();
         obj._uuid = ZaUtil.getItemUUid();
-		obj[DeleteAcctsPgrsDlg._STATUS] = AjxMessageFormat.format(ZaMsg.NAD_DeleteAccStatus, [this._containedObject[this._currentIndex][ZaAccount.A_name]]);
+		obj[DeleteAcctsPgrsDlg._STATUS] = AjxMessageFormat.format(ZaMsg.NAD_DeleteAccStatus, [AjxStringUtil.htmlEncode(this._containedObject[this._currentIndex][ZaAccount.A_name])]);
 		obj[DeleteAcctsPgrsDlg._DELETED_ACCTS] = new Array();
 		this._localXForm.setInstance(obj);
 		this._pollHandler = AjxTimedAction.scheduleAction(this.pollAction, "50");		
@@ -169,7 +169,7 @@ function (result) {
 		obj[DeleteAcctsPgrsDlg._DELETED_ACCTS].push(this._containedObject[this._currentIndex]);
 		this._currentIndex++;
 		if((this._currentIndex < this._containedObject.length) && !this._aborted) {
-			obj.status = AjxMessageFormat.format(ZaMsg.NAD_DeleteAccStatus, [this._containedObject[this._currentIndex][ZaAccount.A_name]]);
+			obj.status = AjxMessageFormat.format(ZaMsg.NAD_DeleteAccStatus, [AjxStringUtil.htmlEncode(this._containedObject[this._currentIndex][ZaAccount.A_name])]);
 			this._pollHandler = AjxTimedAction.scheduleAction(this.pollAction, "50");				
 		} else {
 			//done

--- a/WebRoot/js/zimbraAdmin/accounts/view/MoveAliasXDialog.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/MoveAliasXDialog.js
@@ -136,7 +136,8 @@ function() {
 							{type:_DWT_ALERT_,
 								content:null,ref:"name",
 								getDisplayValue: function (itemVal) {
-									return AjxMessageFormat.format(ZaMsg.MoveAlias_HelpMsg,this.getForm().parent._alias.name);
+									var name = this.getForm().parent._alias.name;
+									return AjxMessageFormat.format(ZaMsg.MoveAlias_HelpMsg, AjxStringUtil.htmlEncode(name));
 								},
 								iconVisible: false,
 								align:_CENTER_,				

--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
@@ -725,6 +725,8 @@ function (ev) {
     var arr = this.widget.getSelection();
     if(arr && arr.length) {
         arr.sort();
+        // When retrieving data from view make sure to html decode it
+        arr = AjxUtil.htmlDecode(arr);
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_fwdAddr_selection_cache, arr);
     } else {
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_fwdAddr_selection_cache, []);
@@ -739,6 +741,8 @@ function (ev) {
     var arr = this.widget.getSelection();
     if(arr && arr.length) {
         arr.sort();
+        // When retrieving data from view make sure to html decode it
+        arr = AjxUtil.htmlDecode(arr);
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_calFwdAddr_selection_cache, arr);
     } else {
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_calFwdAddr_selection_cache, []);
@@ -891,6 +895,8 @@ function (ev) {
     var arr = this.widget.getSelection();
     if(arr && arr.length) {
         arr.sort();
+        // When getting data from view always html decode it
+        arr = AjxUtil.htmlDecode(arr);
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_fp_selection_cache, arr);
     } else
         this.getModel().setInstanceValue(this.getInstance(), ZaAccount.A2_fp_selection_cache, []);
@@ -1303,6 +1309,7 @@ ZaAccountXFormView.getAccountNameInfoItem = function(){
         ZaAccountXFormView.accountNameInfoPool = new Object();
         ZaAccountXFormView.accountNameInfoPool[ZaAccount.A_name] = {ref:ZaAccount.A_name, type:_EMAILADDR_,
                      msgName:ZaMsg.NAD_AccountName,label:ZaMsg.NAD_AccountName, bmolsnr:false,
+                     getDisplayValue: AjxUtil.htmlEncode,
                                         labelLocation:_LEFT_,onChange:ZaAccount.setDomainChanged,forceUpdate:true,
                                         enableDisableChecks:[[ZaItem.hasRight,ZaAccount.RENAME_ACCOUNT_RIGHT]],
                                         visibilityChecks:[]
@@ -1493,7 +1500,9 @@ ZaAccountXFormView.myXFormModifier = function(xFormObject, entry) {
     }
 
     if (ZaItem.hasReadPermission(ZaAccount.A_name, entry)) {
-        headerItems.push({type:_OUTPUT_,ref:ZaAccount.A_name, label:ZaMsg.NAD_Email, labelLocation:_LEFT_, required:false, cssStyle:"word-wrap:break-word;overflow:hidden;"});
+        headerItems.push({type:_OUTPUT_,ref:ZaAccount.A_name, label:ZaMsg.NAD_Email, labelLocation:_LEFT_, required:false, cssStyle:"word-wrap:break-word;overflow:hidden;",
+    		getDisplayValue: AjxUtil.htmlEncode
+    	});
     }
 
     if (ZaItem.hasReadPermission(ZaAccount.A_accountStatus, entry)) {
@@ -2907,12 +2916,10 @@ textFieldCssClass:"admin_xform_number_input"}
                                         trueValue:"TRUE", falseValue:"FALSE"
                                     },
                                     {ref:ZaAccount.A_zimbraPrefMailForwardingAddress, type:_TEXTFIELD_,width:"350px",
-
-labelCssClass:"xform_label", cssClass:"admin_xform_name_input",
+                                        labelCssClass:"xform_label", cssClass:"admin_xform_name_input",
                                         label:ZaMsg.LBL_zimbraPrefMailForwardingAddress,
                                         msgName:ZaMsg.LBL_zimbraPrefMailForwardingAddressMsg,
-
-nowrap:false, labelWrap:true,
+                                        nowrap:false, labelWrap:true,
                                         labelLocation:_LEFT_,
                                         labelCssStyle:"text-align:left;",
                                         align:_LEFT_,
@@ -2922,6 +2929,7 @@ nowrap:false, labelWrap:true,
                                     },
                                 {type:_GROUP_, colSizes:["275px", "*"], numCols: 2, width: "100%", colSpan:2,items:[
                                 {ref:ZaAccount.A_zimbraPrefCalendarForwardInvitesTo, type:_DWT_LIST_, height:"100", width:"350px",
+                                    getDisplayValue: AjxUtil.htmlEncode,
                                     forceUpdate: true, preserveSelection:false, multiselect:true,cssClass: "DLSource",
                                     nowrap:false, labelWrap:true,
                                     headerList:null,onSelection:ZaAccountXFormView.calFwdAddrSelectionListener,label:ZaMsg.zimbraPrefCalendarForwardInvitesTo,
@@ -2959,6 +2967,7 @@ nowrap:false, labelWrap:true,
                                    content: ZaMsg.Alert_Bouncing_Reveal_Hidden_Adds
                                 },
                                 {ref:ZaAccount.A_zimbraMailForwardingAddress, type:_DWT_LIST_, height:"100", width:"350px",
+                                    getDisplayValue: AjxUtil.htmlEncode,
                                     forceUpdate: true, preserveSelection:false, multiselect:true,cssClass: "DLSource",
                                     headerList:null,onSelection:ZaAccountXFormView.fwdAddrSelectionListener,label:ZaMsg.NAD_EditFwdGroup,
                                     labelCssClass:"gridGroupBodyLabel", nowrap:false, labelWrap:true,
@@ -3006,7 +3015,8 @@ nowrap:false, labelWrap:true,
                             items :[
                                 {ref:ZaAccount.A_zimbraForeignPrincipal, type:_DWT_LIST_, height:"200", width:"350px",
                                     forceUpdate: true, preserveSelection:false, multiselect:true,cssClass: "DLSource",
-                                    headerList:null,onSelection:ZaAccountXFormView.fpSelectionListener
+                                    headerList:null,onSelection:ZaAccountXFormView.fpSelectionListener,
+                                    getDisplayValue: AjxUtil.htmlEncode
                                 },
                                 {type:_GROUP_, numCols:7, width:"350px", colSizes:["100px","auto","100px","auto","100px", "auto","100px"],
                                     cssStyle:"margin:10px;padding-bottom:0;",

--- a/WebRoot/js/zimbraAdmin/common/ZaActionStatusView.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaActionStatusView.js
@@ -183,7 +183,7 @@ function() {
 		var icon = ZaActionStatusView.getImageHtml(work);
 
 		this._toast = work.toast;
-		this._toast.popup(level, work.msg, icon, null, work.transitions, work.dismissCallback, work.finishCallback);
+		this._toast.popup(level, AjxStringUtil.htmlEncode(work.msg), icon, null, work.transitions, work.dismissCallback, work.finishCallback);
 	}
 };
 

--- a/WebRoot/js/zimbraAdmin/common/ZaController.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaController.js
@@ -186,10 +186,8 @@ function(msg, ex, style)  {
     }
 
     if (this._errorDialog) {
-        msg = AjxStringUtil.htmlEncode(msg);
         this._errorDialog.setMessage(msg, detailStr, style, ZabMsg.zimbraAdminTitle);
 
-    
         if (!this._errorDialog.isPoppedUp()) {
             this._errorDialog.popup();
         }

--- a/WebRoot/js/zimbraAdmin/common/ZaCurrentAppBar.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaCurrentAppBar.js
@@ -98,6 +98,9 @@ ZaCurrentAppBar.prototype.clearTypeImg = function () {
 
 ZaCurrentAppBar.prototype.setText =
 function(path) {
+    // Html encode path to make sure scripts are not executed when added in dom
+    path = AjxStringUtil.htmlEncode(path);
+
     var text = "";
     var temp = path.split(ZaTree.SEPERATOR);
     this._currentPathItems = temp;

--- a/WebRoot/js/zimbraAdmin/common/ZaErrorDialog.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaErrorDialog.js
@@ -76,6 +76,11 @@ function() {
 
 ZaErrorDialog.prototype.setMessage =
 function(msgStr, detailStr, style, title) {
+	msgStr = AjxStringUtil.htmlEncode(msgStr);
+
+	// If we have a <br> tag in string then we need to maintain decode it, so it will be considered as html tag
+	msgStr = msgStr.replace(/&lt;br\s?(\/)?&gt;/gi, '<br />');
+
 	this._msgStr = msgStr;
 	this._msgStyle = style;
 	this._msgTitle = title;

--- a/WebRoot/js/zimbraAdmin/common/ZaItem.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaItem.js
@@ -593,7 +593,7 @@ function (obj) {
 		return;
 
 	if(obj.name)	
-		this.name = AjxStringUtil.htmlEncode(obj.name);
+		this.name = obj.name;
 
 	if(obj.id)
 		this.id = obj.id;

--- a/WebRoot/js/zimbraAdmin/common/ZaTreeItem.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaTreeItem.js
@@ -106,10 +106,10 @@ ZaTreeItem.prototype.setText =
 function(text) {
 	if (this._initialized) {
 		if (!text) text = "";
-		this._text = this._textCell.innerHTML = text;
+		this._text = this._textCell.innerHTML = AjxStringUtil.htmlEncode(text);
         this._adjustText();
 	} else {
-		this._textParam = text;
+		this._textParam = AjxStringUtil.htmlEncode(text);
 	}
 };
 

--- a/WebRoot/js/zimbraAdmin/cos/controller/ZaCosListController.js
+++ b/WebRoot/js/zimbraAdmin/cos/controller/ZaCosListController.js
@@ -297,13 +297,6 @@ function(ev) {
 		for(var key =0; key < cnt; key++) {
 			var item = arrItems[key];
 			if (item) {
-				if (item.name) {
-					item.name = AjxStringUtil.htmlEncode(item.name);
-				}
-
-				if (item.attrs && item.attrs[ZaCos.A_name]) {
-					item.attrs[ZaCos.A_name] = AjxStringUtil.htmlEncode(item.attrs[ZaCos.A_name]);
-				}
 				//detect whether the deleting item is open in a tab
 				if (ZaApp.getInstance().getTabGroup() && ZaApp.getInstance().getTabGroup().getTabByItemId (item.id)) {
 					this._itemsInTabList.push (item) ;
@@ -372,28 +365,31 @@ function () {
 ZaCosListController.getDlMsgFromList =
 function (listArr) {
 	dlgMsg =  "<br><ul>";
-	var i=0;
+	var i=0, name;
+
 	for(var key in listArr) {
 		if(i > 19) {
 			dlgMsg += "<li>...</li>";
 			break;
 		}
 		dlgMsg += "<li>";
-		if(listArr[key].name.length > 50) {
+
+		name = listArr[key].name;
+		if(name.length > 50) {
 			//split it
 			var endIx = 49;
 			var beginIx = 0; //
-			while(endIx < listArr[key].name.length) { //
-				dlgMsg +=  listArr[key].name.slice(beginIx, endIx); //
+			while(endIx < name.length) { //
+				dlgMsg +=  AjxStringUtil.htmlEncode(name.slice(beginIx, endIx)); //
 				beginIx = endIx + 1; //
-				if(beginIx >= (listArr[key].name.length) ) //
+				if(beginIx >= (name.length) ) //
 					break;
 				
-				endIx = ( listArr[key].name.length <= (endIx + 50) ) ? listArr[key].name.length-1 : (endIx + 50);
+				endIx = ( name.length <= (endIx + 50) ) ? name.length-1 : (endIx + 50);
 				dlgMsg +=  "<br>";	
 			}
 		} else {
-			dlgMsg += listArr[key].name;
+			dlgMsg += AjxStringUtil.htmlEncode(name);
 		}
 		dlgMsg += "</li>";
 		i++;

--- a/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
+++ b/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
@@ -292,14 +292,6 @@ function (by, val) {
     var resp = ZaRequestMgr.invoke(params, reqMgrParams).Body.GetCosResponse;
     this.initFromJS(resp.cos[0]);
 
-    if (this.name) {
-        this.name = AjxStringUtil.htmlEncode(this.name);
-    }
-
-    if (this.attrs[ZaCos.A_name]) {
-        this.attrs[ZaCos.A_name] = AjxStringUtil.htmlEncode(this.attrs[ZaCos.A_name]);
-    }
-
     if(this.attrs[ZaAccount.A_zimbraPrefMailPollingInterval]) {
         var poIntervalInS = ZaUtil.getLifeTimeInSeconds(this.attrs[ZaAccount.A_zimbraPrefMailPollingInterval]);
         if (poIntervalInS >= 1)
@@ -375,7 +367,7 @@ ZaCos.prototype.rename =
 function(newName) {
     var soapDoc = AjxSoapDoc.create("RenameCosRequest", ZaZimbraAdmin.URN, null);
     soapDoc.set("id", this.id);
-    soapDoc.set("newName", AjxStringUtil.htmlEncode(newName));
+    soapDoc.set("newName", newName);
     //var command = new ZmCsfeCommand();
     var params = new Object();
     params.soapDoc = soapDoc;
@@ -421,9 +413,6 @@ function (mods) {
     soapDoc.set("id", this.id);
     for (var aname in mods) {
         gotSomething = true;
-        if (aname === ZaCos.A_name) {
-            mods[aname] = AjxStringUtil.htmlEncode(mods[aname]);
-        }
         //multi value attribute
         if(mods[aname] instanceof Array) {
             var cnt = mods[aname].length;

--- a/WebRoot/js/zimbraAdmin/cos/view/ZaCosXFormView.js
+++ b/WebRoot/js/zimbraAdmin/cos/view/ZaCosXFormView.js
@@ -76,15 +76,6 @@ function(entry) {
     if(entry.id)
         this._containedObject.id = entry.id;
 
-    if (entry.name) {
-        entry.name = AjxStringUtil.htmlEncode(entry.name);
-    }
-
-    if (entry.attrs && entry.attrs[ZaCos.A_name]) {
-        entry.attrs[ZaCos.A_name] = AjxStringUtil.htmlEncode(entry.attrs[ZaCos.A_name]);
-    }
-
-
     for (var a in entry.attrs) {
         var modelItem = this._localXForm.getModel().getItem(a) ;
         if ((modelItem != null && modelItem.type == _LIST_)
@@ -634,6 +625,7 @@ ZaCosXFormView.myXFormModifier = function(xFormObject, entry) {
 
     var headerItems = [    {type:_AJX_IMAGE_, src:"COS_32", label:null,rowSpan:2},
                             {type:_OUTPUT_, ref:ZaCos.A_name, label:null,cssClass:"AdminTitle",
+                                getDisplayValue: AjxUtil.htmlEncode,
                                 visibilityChecks:[ZaItem.hasReadPermission], height: 32, rowSpan:2},
                             {type:_OUTPUT_, ref:ZaItem.A_zimbraId, label:ZaMsg.NAD_ZimbraID,visibilityChecks:[ZaItem.hasReadPermission]},
                             {type:_OUTPUT_, ref:ZaItem.A_zimbraCreateTimestamp,

--- a/WebRoot/js/zimbraAdmin/cos/view/ZaNewCosXWizard.js
+++ b/WebRoot/js/zimbraAdmin/cos/view/ZaNewCosXWizard.js
@@ -102,7 +102,7 @@ function() {
         }
         var cos = ZaItem.create(this._containedObject, ZaCos, "ZaCos");
         if(cos!=null) {
-            cos.name= AjxStringUtil.htmlEncode(this._containedObject.attrs[ZaCos.A_name]);
+            cos.name = this._containedObject.attrs[ZaCos.A_name];
             cos.create(cos.name,this._containedObject.attrs);
             ZaApp.getInstance().getCosController().fireCreationEvent(cos);
             this.popdown();

--- a/WebRoot/js/zimbraAdmin/dl/model/ZaDistributionList.js
+++ b/WebRoot/js/zimbraAdmin/dl/model/ZaDistributionList.js
@@ -1232,7 +1232,7 @@ ZaDistributionList.myXModel = {
 			   function (value, form, formItem, instance) {				   
 				   if (value){
 					  	if(AjxUtil.isValidEmailNonReg(value)) {
-						   return AjxStringUtil.htmlEncode(value);
+						   return value;
 					   } else {
 						   throw ZaMsg.ErrorInvalidEmailAddress;
 					   }

--- a/WebRoot/js/zimbraAdmin/dl/view/ZaDLXFormView.js
+++ b/WebRoot/js/zimbraAdmin/dl/view/ZaDLXFormView.js
@@ -841,9 +841,11 @@ function (rawQueryString, myName) {
 
 ZaDLXFormView.aliasSelectionListener = 
 function (ev) {
-	var arr = this.widget.getSelection();	
+	var arr = this.widget.getSelection();
 	if(arr && arr.length) {
 		arr.sort();
+		//the selection values are HTML encoded, need to decode them before saving to cache.
+		arr = AjxUtil.htmlDecode(arr);
 		this.getModel().setInstanceValue(this.getInstance(), ZaDistributionList.A2_alias_selection_cache, arr);
 	} else {
 		this.getModel().setInstanceValue(this.getInstance(), ZaDistributionList.A2_alias_selection_cache, null);
@@ -959,6 +961,8 @@ function (ev) {
 	var arr = this.widget.getSelection();
 	if(arr && arr.length) {
 		arr.sort();
+		// When getting data from view make sure to html decode it
+		arr = AjxUtil.htmlDecode(arr);
 		this.getModel().setInstanceValue(this.getInstance(), ZaDistributionList.A2_owners_selection_cache, arr);
 	} else {
 		this.getModel().setInstanceValue(this.getInstance(), ZaDistributionList.A2_owners_selection_cache, null);
@@ -2067,7 +2071,8 @@ ZaDLXFormView.myXFormModifier = function(xFormObject, entry) {
 				width:"100%", numCols:1,colSizes:["auto"],
 				label:ZaMsg.NAD_EditDLAliasesGroup,
 				items :[
-					{ref:ZaAccount.A_zimbraMailAlias, type:_DWT_LIST_, height:"200", width:"350px", 
+					{ref:ZaAccount.A_zimbraMailAlias, type:_DWT_LIST_, height:"200", width:"350px",
+						getDisplayValue: AjxUtil.htmlEncode,
 						forceUpdate: true, preserveSelection:false, multiselect:true,cssClass: "DLSource", 
 						headerList:null,onSelection:ZaDLXFormView.aliasSelectionListener
 					},
@@ -2113,6 +2118,7 @@ ZaDLXFormView.myXFormModifier = function(xFormObject, entry) {
 				label: ZaMsg.DLXV_GroupLabelDLOwners,
 				items :[
 					{ref:ZaDistributionList.A2_DLOwners, type:_DWT_LIST_, height:"200", width:"350px",
+						getDisplayValue: AjxUtil.htmlEncode,
 						forceUpdate: true, preserveSelection:false, multiselect:true,cssClass: "DLSource",
 						headerList:null,onSelection:ZaDLXFormView.ownerSelectionListener
 					},
@@ -2187,8 +2193,9 @@ ZaDLXFormView.myXFormModifier = function(xFormObject, entry) {
 	}
 
     var headerItems = [{type:_AJX_IMAGE_, src:"Group_32", label:null, rowSpan:3},
-						{type:_OUTPUT_, ref:"name", label:null,cssClass:"AdminTitle", height:"auto", width:350, rowSpan:3, cssStyle:"word-wrap:break-word;overflow:hidden"}
-						] ;
+						{type:_OUTPUT_, ref:"name", label:null,cssClass:"AdminTitle", height:"auto", width:350, rowSpan:3, cssStyle:"word-wrap:break-word;overflow:hidden",
+							getDisplayValue: AjxUtil.htmlEncode
+						}] ;
 
     if (ZaItem.hasReadPermission (ZaItem.A_zimbraId, entry)) 
         headerItems.push (  {type:_OUTPUT_, ref:ZaItem.A_zimbraId, label:ZaMsg.NAD_ZimbraID}) ;

--- a/WebRoot/js/zimbraAdmin/dl/view/ZaNewDLXWizard.js
+++ b/WebRoot/js/zimbraAdmin/dl/view/ZaNewDLXWizard.js
@@ -2235,6 +2235,7 @@ ZaNewDLXWizard.myXFormModifier = function(xFormObject, entry) {
                         {
                             ref: ".",
                             type: _EMAILADDR_,
+                            getDisplayValue: AjxUtil.htmlEncode,
                             label: null,
                             enableDisableChecks: [],
                             visibilityChecks: []

--- a/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainController.js
+++ b/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainController.js
@@ -292,7 +292,7 @@ function () {
 		return false;
 	// check validation expression, which should be email-like pattern
 	if(tmpObj.attrs[ZaDomain.A_zimbraMailAddressValidationRegex]) {
-		var regList = AjxStringUtil.htmlEncode(tmpObj.attrs[ZaDomain.A_zimbraMailAddressValidationRegex]);
+		var regList = tmpObj.attrs[ZaDomain.A_zimbraMailAddressValidationRegex];
 		var islegal = true;
 		var regval = null;
 		if(regList && regList instanceof Array) {
@@ -309,9 +309,9 @@ function () {
 			}
 		}
 		if(!islegal) {
-			this._errorDialog.setMessage(AjxMessageFormat.format(ZaMsg.ERROR_MSG_EmailValidReg, regval), 
+			this._errorDialog.setMessage(AjxMessageFormat.format(ZaMsg.ERROR_MSG_EmailValidReg, regval),
 				null, DwtMessageDialog.CRITICAL_STYLE, ZabMsg.zimbraAdminTitle);
-                        this._errorDialog.popup();
+			this._errorDialog.popup();
 			return islegal;
 		}
 	}

--- a/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainListController.js
+++ b/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainListController.js
@@ -485,29 +485,31 @@ function () {
 
 ZaDomainListController.getDlMsgFromList =
 function (listArr) {
-    var i = 0;
+    var i = 0, name;
 	var	dlgMsg = "<br><ul>";
+
 	for(var key in listArr) {
 		if(i > 19) {
 			dlgMsg += "<li>...</li>";
 			break;
 		}
 		dlgMsg += "<li>";
-		if(listArr[key].name.length > 50) {
+		name = listArr[key].name;
+		if(name.length > 50) {
 			//split it
 			var endIx = 49;
 			var beginIx = 0; //
-			while(endIx < listArr[key].name.length) { //
-				dlgMsg +=  listArr[key].name.slice(beginIx, endIx); //
+			while(endIx < name.length) { //
+				dlgMsg +=  AjxStringUtil.htmlEncode(name.slice(beginIx, endIx)); //
 				beginIx = endIx + 1; //
-				if(beginIx >= (listArr[key].name.length) ) //
+				if(beginIx >= (name.length) ) //
 					break;
 				
-				endIx = ( listArr[key].name.length <= (endIx + 50) ) ? listArr[key].name.length-1 : (endIx + 50);
+				endIx = ( name.length <= (endIx + 50) ) ? name.length-1 : (endIx + 50);
 				dlgMsg +=  "<br>";	
 			}
 		} else {
-			dlgMsg += listArr[key].name;
+			dlgMsg += AjxStringUtil.htmlEncode(name);
 		}
 		dlgMsg += "</li>";
 		i++;

--- a/WebRoot/js/zimbraAdmin/domains/model/ZaDomain.js
+++ b/WebRoot/js/zimbraAdmin/domains/model/ZaDomain.js
@@ -2388,12 +2388,11 @@ ZaDomain.myXModel = {
         {id:ZaItem.A_zimbraDomainAliasTargetId, type:_STRING_, ref:"attrs/" + ZaItem.A_zimbraDomainAliasTargetId},                
 		{id:ZaItem.A_zimbraCreateTimestamp, ref:"attrs/" + ZaItem.A_zimbraCreateTimestamp},
 		{id:ZaDomain.A_domainName, type:_STRING_, ref:"attrs/" + ZaDomain.A_domainName, maxLength:255,constraints: {type:"method", value:
-                   function (value) {
-                         value = value.replace(/(^\s*)/g, "");
-                                                 return AjxStringUtil.htmlEncode(value);
-                                           }
-
-                           } },
+           function (value) {
+               value = value.replace(/(^\s*)/g, "");
+               return value;
+           }}
+        },
 		{id:ZaDomain.A_zimbraPublicServiceHostname, type:_STRING_, ref:"attrs/" + ZaDomain.A_zimbraPublicServiceHostname, maxLength:255},
 		{id:ZaDomain.A_zimbraPublicServiceProtocol, type:_STRING_, ref:"attrs/" + ZaDomain.A_zimbraPublicServiceProtocol, maxLength:255, defaultValue:"http"},
 		{id:ZaDomain.A_zimbraPublicServicePort, type:_NUMBER_, ref:"attrs/" + ZaDomain.A_zimbraPublicServicePort, minInclusive: 0, maxInclusive:65535, defaultValue:80},

--- a/WebRoot/js/zimbraAdmin/domains/view/ZaNewDomainXWizard.js
+++ b/WebRoot/js/zimbraAdmin/domains/view/ZaNewDomainXWizard.js
@@ -737,7 +737,9 @@ ZaNewDomainXWizard.myXFormModifier = function(xFormObject, entry) {
 				{type:_CASE_, caseKey:ZaNewDomainXWizard.GENERAL_STEP, colSizes:["200px","*"],numCols:2,
 					items: [{type:_ZAWIZ_TOP_GROUPER_, colSpan:"*", label:ZaMsg.TABT_GeneralPage,
                         items:[
-                            {ref:ZaDomain.A_domainName, type:_TEXTFIELD_, label:ZaMsg.Domain_DomainName,labelLocation:_LEFT_, required:true, width:200},
+                            {ref:ZaDomain.A_domainName, type:_TEXTFIELD_, label:ZaMsg.Domain_DomainName,labelLocation:_LEFT_, required:true, width:200,
+                                getDisplayValue: AjxUtil.htmlEncode
+                            },
                             {ref:ZaDomain.A_zimbraPublicServiceHostname, type:_TEXTFIELD_, label:ZaMsg.Domain_zimbraPublicServiceHostname,labelLocation:_LEFT_, width:200},
                             {ref:ZaDomain.A_zimbraPublicServiceProtocol, type:_OSELECT1_, choices:ZaDomain.protocolChoices, label:ZaMsg.Domain_zimbraPublicServiceProtocol,labelLocation:_LEFT_},
                             {ref:ZaDomain.A_zimbraPublicServicePort, type:_TEXTFIELD_, label:ZaMsg.Domain_zimbraPublicServicePort,labelLocation:_LEFT_, width:100},
@@ -830,7 +832,9 @@ ZaNewDomainXWizard.myXFormModifier = function(xFormObject, entry) {
                                             items:[
                                                 {ref:ZaDomain.A2_new_gal_sync_account_name, width:130, label:null, type:_TEXTFIELD_, visibilityChecks:[],enableDisableChecks:[]},
                                                 {type:_OUTPUT_, value:"@", visibilityChecks:[],enableDisableChecks:[]},
-                                                {type:_OUTPUT_,refPath:ZaDomain.A_domainName,label:null,align:_LEFT_, visibilityChecks:[],enableDisableChecks:[]}
+                                                {type:_OUTPUT_,refPath:ZaDomain.A_domainName,label:null,align:_LEFT_, visibilityChecks:[],enableDisableChecks:[],
+                                                    getDisplayValue: AjxUtil.htmlEncode
+                                                }
                                             ],
                                             enableDisableChangeEventSources:[ZaDomain.A2_create_gal_acc],
                                             enableDisableChecks:[[XForm.checkInstanceValue,ZaDomain.A2_create_gal_acc,"TRUE"]],
@@ -1596,7 +1600,7 @@ ZaNewDomainXWizard.myXFormModifier = function(xFormObject, entry) {
 					items:[
 						{type:_DWT_ALERT_,content:null,ref:ZaDomain.A_domainName,
 							getDisplayValue: function (itemVal) {
-								return AjxMessageFormat.format(ZaMsg.Domain_VH_Explanation,itemVal);
+								return AjxMessageFormat.format(ZaMsg.Domain_VH_Explanation, AjxStringUtil.htmlEncode(itemVal));
 							},
 							iconVisible: false,
 							align:_CENTER_,				

--- a/WebRoot/js/zimbraAdmin/globalconfig/view/GlobalConfigXFormView.js
+++ b/WebRoot/js/zimbraAdmin/globalconfig/view/GlobalConfigXFormView.js
@@ -71,6 +71,8 @@ GlobalConfigXFormView.blockedExtSelectionListener = function() {
     var arr = this.widget.getSelection();
     if (arr && arr.length) {
         arr.sort();
+        // HTML Decode data received from view
+        arr = AjxUtil.htmlDecode(arr);
         this.getModel().setInstanceValue(this.getInstance(), ZaGlobalConfig.A2_blocked_extension_selection, arr);
     } else {
         this.getModel().setInstanceValue(this.getInstance(), ZaGlobalConfig.A2_blocked_extension_selection, null);
@@ -572,6 +574,7 @@ GlobalConfigXFormView.myXFormModifier = function(xFormObject, entry) {
                                             {
                                                 ref : ZaGlobalConfig.A_zimbraMtaBlockedExtension,
                                                 type : _DWT_LIST_,
+                                                getDisplayValue: AjxUtil.htmlEncode,
                                                 height : "200",
                                                 width : "98%",
                                                 cssClass : "DLTarget",

--- a/WebRoot/js/zimbraAdmin/resource/view/ZaResourceXFormView.js
+++ b/WebRoot/js/zimbraAdmin/resource/view/ZaResourceXFormView.js
@@ -173,6 +173,9 @@ function (ev) {
 	var arr = this.widget.getSelection();	
 	if(arr && arr.length) {
 		arr.sort();
+		// When getting data from view make sure to html decode it before storing
+		arr = AjxUtil.htmlDecode(arr);
+
 		this.getModel().setInstanceValue(this.getInstance(), ZaResource.A2_calFwdAddr_selection_cache, arr);	
 	} else {
 		this.getModel().setInstanceValue(this.getInstance(), ZaResource.A2_calFwdAddr_selection_cache, []);
@@ -483,7 +486,9 @@ ZaResourceXFormView.myXFormModifier = function(xFormObject, entry) {
 						
 	var headerItems = [	{type:_AJX_IMAGE_, ref:ZaResource.A_zimbraCalResType, src:"Resource_32", label:null, rowSpan:3, choices: imgChoices, cssStyle:"margin:auto;"},
 						{type:_OUTPUT_, ref:ZaResource.A_displayname, label:null,cssClass:"AdminTitle", height:"auto", width:350, rowSpan:3, cssStyle:"word-wrap:break-word;overflow:hidden;",
-                             visibilityChecks:[ZaItem.hasReadPermission]}];
+                             visibilityChecks:[ZaItem.hasReadPermission],
+                             getDisplayValue: AjxUtil.htmlEncode
+                         }];
 						
 	/*headerItems.push({type:_OUTPUT_, ref:ZaResource.A_COSId, labelLocation:_LEFT_, label:ZaMsg.NAD_ClassOfService, 
 		choices:this.cosChoices,getDisplayValue:function(newValue) {
@@ -630,7 +635,8 @@ ZaResourceXFormView.myXFormModifier = function(xFormObject, entry) {
 									headerList:null,onSelection:ZaResourceXFormView.calFwdAddrSelectionListener,label:ZaMsg.zimbraPrefCalendarForwardInvitesTo,
                                     visibilityChecks:[ZaItem.hasReadPermission],
                                     labelCssClass:"gridGroupBodyLabel",
-                                    labelCssStyle:"text-align:left;border-right:1px solid;"
+                                    labelCssStyle:"text-align:left;border-right:1px solid;",
+                                    getDisplayValue: AjxUtil.htmlEncode
 								},
 								{type:_GROUP_, numCols:6, width:"625px",colSizes:["275","100px","auto","100px","auto","100px"], colSpan:2,
 									cssStyle:"margin:10px;padding-bottom:0;",
@@ -708,7 +714,11 @@ ZaResourceXFormView.myXFormModifier = function(xFormObject, entry) {
 									form.signatureChoices
 											.setChoices(tempChoice);
 									form.signatureChoices.dirtyChoices();
-									return value;
+
+									return value.map(function(val) {
+										// Clone object to break reference so we will not be modifying the model data
+										return new ZaSignature(AjxStringUtil.htmlEncode(val.name), val.id, AjxStringUtil.htmlEncode(val.content), val.type);
+									});
 								}
 							},
 							{

--- a/WebRoot/js/zimbraAdmin/resource/view/ZaResourceXFormView.js
+++ b/WebRoot/js/zimbraAdmin/resource/view/ZaResourceXFormView.js
@@ -272,6 +272,11 @@ function (ev) {
 	var arr = this.widget.getSelection();
 	if(arr && arr.length) {
 		arr.sort();
+		// When retrieving data from view make sure to html decode it
+		arr = arr.map(function(item) {
+			// Clone object to break reference so we will not be modifying the original object
+			return new ZaSignature(AjxStringUtil.htmlDecode(item.name), item.id, AjxStringUtil.htmlDecode(item.content), item.type);
+		});
 		this.getModel().setInstanceValue(this.getInstance(), ZaResource.A2_signature_selection_cache, arr);
 	} else {
 		this.getModel().setInstanceValue(this.getInstance(), ZaResource.A2_signature_selection_cache, []);
@@ -522,11 +527,11 @@ ZaResourceXFormView.myXFormModifier = function(xFormObject, entry) {
 						 });
 	
     if (ZaItem.hasReadPermission(ZaResource.A_mailHost, entry)) {
-	    headerItems.push({type:_OUTPUT_, ref:ZaResource.A_mailHost, labelLocation:_LEFT_,label:ZaMsg.NAD_MailServer});
+	    headerItems.push({type:_OUTPUT_, ref:ZaResource.A_mailHost, labelLocation:_LEFT_,label:ZaMsg.NAD_MailServer, getDisplayValue: AjxUtil.htmlEncode});
     }
 	
     if (ZaItem.hasReadPermission(ZaResource.A_name, entry))
-    	headerItems.push({type:_OUTPUT_, ref:ZaResource.A_name, label:ZaMsg.NAD_Email, labelLocation:_LEFT_, required:false});
+    	headerItems.push({type:_OUTPUT_, ref:ZaResource.A_name, label:ZaMsg.NAD_Email, labelLocation:_LEFT_, required:false, getDisplayValue: AjxUtil.htmlEncode});
 
     if (ZaItem.hasReadPermission(ZaResource.A_accountStatus, entry))
 	    headerItems.push({type:_OUTPUT_,  ref:ZaResource.A_accountStatus, label:ZaMsg.NAD_ResourceStatus, labelLocation:_LEFT_, choices:ZaResource.accountStatusChoices});

--- a/WebRoot/js/zimbraAdmin/search/view/ZaSearchBubbleList.js
+++ b/WebRoot/js/zimbraAdmin/search/view/ZaSearchBubbleList.js
@@ -272,13 +272,13 @@ function(ev) {
 
 ZaSearchBubble.prototype._mouseOverAction =
 function(ev) {
-	var toolTipContent = AjxStringUtil.htmlEncode(this.getToolTip());
+	var toolTipContent = this.getToolTip();
 	this.setToolTipContent(toolTipContent);
 	return true;
 }
 
 ZaSearchBubble.prototype.getToolTip =
 function(){
-    return this.query;
+    return AjxStringUtil.htmlEncode(this.query);
 }
 

--- a/WebRoot/js/zimbraAdmin/search/view/ZaSearchField.js
+++ b/WebRoot/js/zimbraAdmin/search/view/ZaSearchField.js
@@ -488,7 +488,7 @@ function () {
 		var n = ZaSearch.SAVED_SEARCHES[i].name ;
 		var q = ZaSearch.SAVED_SEARCHES[i].query ;
 		var mItem =  new DwtMenuItem ({parent:this._savedSearchMenu, id: (ZaId.getMenuItemId(ZaId.SEARCH_QUERY) + "_" + (i+1))}) ;
-		mItem.setText(n) ;
+		mItem.setText(AjxStringUtil.htmlEncode(n));
 		mItem.setSize(b.width) ;
 		mItem.addSelectionListener(new AjxListener(this, ZaSearchField.prototype.selectSavedSearch, [n, q]));
 		mItem.addListener(DwtEvent.ONMOUSEUP, new AjxListener(this, this._savedSearchItemMouseUpListener, [n, q] ));
@@ -854,7 +854,7 @@ ZaSaveSearchDialog.prototype.okCallback =
 function() {
 	//if(window.console && window.console.log) console.debug("Ok button of saved search dialog is clicked.");
 	var savedSearchArr = [] ;
-	var nameValue = AjxStringUtil.htmlEncode(this._nameInput.value);
+	var nameValue = this._nameInput.value;
 	var queryValue =  this._queryInput.value ;
 
 	if(!nameValue) {

--- a/WebRoot/js/zimbraAdmin/servers/view/ZaServerVolumesListView.js
+++ b/WebRoot/js/zimbraAdmin/servers/view/ZaServerVolumesListView.js
@@ -71,11 +71,11 @@ function(item) {
 				html[idx++] = "</td>";
 			} else if(field == ZaServer.A_VolumeName) {
 				html[idx++] = "<td align=left height=20px width=" + this._headerList[i]._width + ">";
-				html[idx++] = item[ZaServer.A_VolumeName];
+				html[idx++] = AjxStringUtil.htmlEncode(item[ZaServer.A_VolumeName]);
 				html[idx++] = "</td>";
 			} else if(field == ZaServer.A_VolumeRootPath) {
 				html[idx++] = "<td align=left height=20px width=" + this._headerList[i]._width + ">";
-				html[idx++] = item[ZaServer.A_VolumeRootPath];
+				html[idx++] = AjxStringUtil.htmlEncode(item[ZaServer.A_VolumeRootPath]);
 				html[idx++] = "</td>";
 			} else if(field == ZaServer.A_VolumeType) {
 				html[idx++] = "<td align=left height=20px width=" + this._headerList[i]._width + ">";


### PR DESCRIPTION
Issue:
- Previous fixes of XSS prevented XSS attack from admin console as it modified data before saving, but this will not prevent XSS attack where data is set using zmprov

Resolution:
- revisited fixes done as part of https://bugzilla.zimbra.com/show_bug.cgi?id=103997, https://bugzilla.zimbra.com/show_bug.cgi?id=104777, https://bugzilla.zimbra.com/show_bug.cgi?id=104413, https://bugzilla.zimbra.com/show_bug.cgi?id=104414, https://bugzilla.zimbra.com/show_bug.cgi?id=104791
- previous fixes were modifying data in the model itself, which created lot of issues where we were saving &amtp;gt; and &amtp;lt; instead of < and > symbols in database
- ideally XSS should be handled at view layer only so whenever we show data which can have scripts then html encode it before showing, we should never modify data in the model, this can have really bad implications
- some generic fixes are done in ZaErrorDialog.js, ZaActionStatusView.js and ZaTreeItem.js so we don't have to encode data before passing to these components
- Removed html encoding from ZaItem.js which was modifying data instead of view
- When passing data to edit dialogs make sure to html decode data as we are taking data from view and that data will be in encoded form