### PR TITLE
ZCS-1661 Use zip published by zm-timezones repo to get timezone data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ WebRoot/js/zimbra
 WebRoot/keys/AjxKeys*.properties
 WebRoot/messages/AjxMsg*.properties
 WebRoot/messages/I18nMsg*.properties
+WebRoot/messages/TzMsg*.properties
 WebRoot/modernizr
 WebRoot/yui

--- a/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
+++ b/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
@@ -399,7 +399,7 @@ function(aIsAuthTokenPresent) {
 ZaZimbraAdmin.reload_msg = function () {
     //if(window.console && window.console.log) console.log("Reloading the message ...");
     var includes = [] ;
-    includes.push ( [appContextPath , "/res/" , "I18nMsg,AjxMsg,ZMsg,ZaMsg,ZabMsg,AjxKeys" , ".js?v=",
+    includes.push ( [appContextPath , "/res/" , "I18nMsg,TzMsg,AjxMsg,ZMsg,ZaMsg,ZabMsg,AjxKeys" , ".js?v=",
                         appVers , ZaZimbraAdmin.LOCALE_QS].join("") );
 
     //the dynamic script load is asynchronous, may need a callback to make sure all the messages are actually loaded

--- a/WebRoot/public/Docs.jsp
+++ b/WebRoot/public/Docs.jsp
@@ -128,7 +128,7 @@ If not, see <https://www.gnu.org/licenses/>.
         -->
     </style>
     <jsp:include page="Resources.jsp">
-        <jsp:param name="res" value="I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys" />
+        <jsp:param name="res" value="I18nMsg,TzMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys" />
         <jsp:param name="skin" value="${zm:cook(skin)}" />
     </jsp:include>
     <jsp:include page="Boot.jsp"/>
@@ -167,7 +167,7 @@ If not, see <https://www.gnu.org/licenses/>.
             }
         %>
         <jsp:include page="Resources.jsp">
-            <jsp:param name="res" value="I18nMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,AjxTemplateMsg" />
+            <jsp:param name="res" value="I18nMsg,TzMsg,AjxMsg,ZMsg,ZmMsg,AjxKeys,ZmKeys,AjxTemplateMsg" />
             <jsp:param name="skin" value="${skin}" />
         </jsp:include>
         <link href='${contextPath}/css/common,dwt,msgview,login,zm,spellcheck,images,skin.css?v=${vers}${isDebug?"&debug=1":""}&skin=${zm:cook(skin)}' rel='stylesheet' type="text/css">

--- a/WebRoot/public/admin.jsp
+++ b/WebRoot/public/admin.jsp
@@ -182,7 +182,7 @@
         appNewUI     = ${isNewUI};
 	</script>
 <jsp:include page="Resources.jsp">
-	<jsp:param name="res" value="I18nMsg,AjxMsg,ZMsg,ZaMsg,ZabMsg,AjxKeys" />
+	<jsp:param name="res" value="I18nMsg,TzMsg,AjxMsg,ZMsg,ZaMsg,ZabMsg,AjxKeys" />
 	<jsp:param name="skin" value="${skin}" />
 </jsp:include>
 <style type="text/css">

--- a/WebRoot/public/proto/index.jsp
+++ b/WebRoot/public/proto/index.jsp
@@ -38,7 +38,7 @@
 <link rel='stylesheet' type="text/css"
 	  href='<%=path%>/css/common,dwt,msgview,login,zm,spellcheck,wiki,images,skin.css?debug=true'
 >
-<script src='<%=path%>/messages/I18nMsg,AjxMsg,ZMsg,ZaMsg,ZmMsg.js?debug=true'></script>
+<script src='<%=path%>/messages/I18nMsg,TzMsg,AjxMsg,ZMsg,ZaMsg,ZmMsg.js?debug=true'></script>
 <script src='<%=path%>/js/ajax/boot/AjxEnv.js'></script>
 <script src='<%=path%>/js/ajax/boot/AjxLoader.js'></script>
 <script src='<%=path%>/js/ajax/boot/AjxPackage.js'></script>

--- a/build.xml
+++ b/build.xml
@@ -29,9 +29,6 @@
 	<property name="webxml.zimbraHttpDosFilterMaxRequestsPerSec" value="30" />
 	<property name="webxml.zimbraHttpContextPathBasedThreadPoolBalancingFilterRules" value="/service:max=10%, /soap:max=40%, /zimbra:max=40%" />
 
-    <!-- zm-timezones -->
-    <property name='timezones.dir' value='${this.zwc.basedir}/../zm-timezones'/>
-
     <property name='lib.dir' value='${this.zwc.basedir}/jars'/>
     <property name="jsdoctoolkit.dir" location="${lib.dir}/jsdoc-toolkit-2.3.0" />
 
@@ -213,7 +210,7 @@
 
 <!-- add build-ajax in dependency once zm-ajax built script is ivy based -->
     <target name="war"
-            depends="resolve,init,templates,images,styles,settings,copy-ajax,jam-files,compress"
+            depends="resolve,init,images,styles,settings,copy-ajax,jam-files,compress"
             description="Builds all dependencies and assembles the war file.">
         <antcall target="assemble-war"/>
     </target>
@@ -222,23 +219,23 @@
 
         <sync todir="${js.dir}">
             <fileset dir="${ajax.dir}/${js.dir}"/>
-                <preserveintarget>
-            <include name="**"/>
-        </preserveintarget>
+            <preserveintarget>
+                <include name="**"/>
+            </preserveintarget>
         </sync>  
            
         <mkdir dir='${keys.dir}'/>
          <sync todir="${web.dir}/keys">
             <fileset dir="${ajax.dir}/${web.dir}/keys"/>
-                <preserveintarget>
-            <include name="**"/>
+            <preserveintarget>
+                <include name="**"/>
             </preserveintarget>
         </sync>
         
         <sync todir="${web.dir}/messages">
             <fileset dir="${ajax.dir}/${web.dir}/messages"/>
-                <preserveintarget>
-            <include name="**"/>
+            <preserveintarget>
+                <include name="**"/>
             </preserveintarget>
         </sync>
 
@@ -722,29 +719,29 @@
 
 
     <target name='timezones' >
-        <property name='tz.data' value='${timezones.dir}/conf/timezones.ics'/>
-        <property name='tz.dir' value='${build.js.dir}/ajax/util'/>
-        <property name='tz.file' value='${tz.dir}/AjxTimezoneData.js'/>
+        <!-- Download timezones zip -->
+        <ivy:install organisation="zimbra" module="zm-timezones" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver-zip" to="build-tmp" overwrite="true" transitive="true" type="zip" />
 
-        <dependset>
-            <srcfilelist dir="." files='${tz.data}'/>
-            <targetfilelist dir='.' files='${tz.file}'/>
-        </dependset>
+        <unzip dest="${build.tmp.dir}/zm-timezones" overwrite="true">
+            <fileset dir="${build.tmp.dir}">
+                <include name="**/zm-timezones-*.zip"/>
+            </fileset>
+        </unzip>
 
-        <if>
-            <not>
-                <available file='${tz.file}'/>
-            </not>
-            <then>
-                <taskdef name='timezones'
-                         classname='com.zimbra.kabuki.tools.tz.GenerateDataTask'
-                         classpathref='class.path'
-                        />
+        <!-- Copy timezone related files to proper folders -->
+        <sync todir="${js.dir}/ajax/util">
+            <fileset dir="${build.tmp.dir}/zm-timezones/js"/>
+            <preserveintarget>
+                <include name="*.js"/>
+            </preserveintarget>
+        </sync>
 
-                <mkdir dir='${tz.dir}'/>
-                <timezones src='${tz.data}' dest='${tz.file}'/>
-            </then>
-        </if>
+        <sync todir="${web.dir}/messages">
+            <fileset dir="${build.tmp.dir}/zm-timezones/messages"/>
+            <preserveintarget>
+                <include name="*.properties"/>
+            </preserveintarget>
+        </sync>
     </target>
 
 

--- a/ivy.xml
+++ b/ivy.xml
@@ -5,7 +5,6 @@
  <info organisation="zimbra" module="zm-admin-console" status="integration">
  </info>
 
-
  <dependencies>
   <dependency org="org.glassfish.gmbal" name="gmbal-api-only" rev="2.2.6"/>
   <dependency org="javax.xml.bind" name="jaxb-api" rev="2.2.6"/>


### PR DESCRIPTION
zm-admin-console:ivy.xml
   - add dependency on zm-timezones repo

zm-admin-console:build.xml
   - change timezones target to get published zip from zm-timezones repo
   - extract timezone files from zip and copy to appropriate locations
   - templates and timezones target are already defined as dependencies for jam-files target so no need to explicitly call those targets