### PR TITLE
ZCS-1326 Create separate versions of zm-ajax for zm-web-client & zm-admin-console

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,7 @@
 
 ## Dependencies
 - zm-timezones
-- zm-ajax
+- zm-admin-ajax
 - zm-taglib
 - zm-soap
 - zm-store
@@ -16,8 +16,8 @@
 - create .zcs-deps folder in home directory
 - clone zimbra-package-stub at same level: git clone https://github.com/Zimbra/zimbra-package-stub.git 
 - clone zm-zcs at same level: git clone ssh://git@stash.corp.synacor.com:7999/zimbra/zm-zcs.git 
-- clone zm-timezones & zm-ajax.
-- zm-ajax is built already.
+- clone zm-timezones & zm-admin-ajax.
+- zm-admin-ajax is built already.
 - copy following jars in the .zcs-deps folder:
     - ant-contrib-1.0b1.jar
 

--- a/build.xml
+++ b/build.xml
@@ -1,6 +1,6 @@
 <project xmlns:ivy="antlib:org.apache.ivy.ant" name="zm-admin-console" default="war">
     <import file="../zm-zcs/ant-global.xml"/>
-    <property name="ajax.dir" location="../zm-ajax" />
+    <property name="ajax.dir" location="../zm-admin-ajax" />
     <property name="ajax.src.dir" location="${ajax.dir}/src" />
     <property name="ajax.build.dir" location="${ajax.dir}/build" />  
 
@@ -210,8 +210,7 @@
         <property name='war.compress' value='true'/>
         <property name='web.excludes' value='${common.web.excludes},js/zimbraAdmin/**,test/**'/>
     </target>
-
-<!-- add build-ajax in dependency once zm-ajax built script is ivy based -->
+    
     <target name="war"
             depends="resolve,init,templates,images,styles,settings,copy-ajax,jam-files,compress"
             description="Builds all dependencies and assembles the war file.">
@@ -265,10 +264,6 @@
         
     </target>
 
-    <target name="build-ajax">
-        <ant dir="${ajax.dir}" target="zm-ajax" inheritAll="false"/>
-    </target>
-
     <target name="assemble-war" depends="webxml-package-replace, resolve" description="Assembles the war file.  Assumes that all dependencies have been built.  Octopus/ZimbraWebClient/build.xml calls the war target, modifies files in ZimbraWebClient/build, and then calls this target.">
         <mkdir dir='${build.war.dir}'/>
 
@@ -276,7 +271,7 @@
         <ivy:install organisation="zimbra" module="zm-client" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="zimbra" module="zm-taglib" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="zimbra" module="zm-store" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
-        <ivy:install organisation="zimbra" module="zm-ajax" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
+        <ivy:install organisation="zimbra" module="zm-admin-ajax" revision="latest.integration" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="org.glassfish.gmbal" module="gmbal-api-only" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="javax.xml.bind" module="jaxb-api" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>
         <ivy:install organisation="com.sun.xml.bind" module="jaxb-impl" revision="2.2.6" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" type="jar"/>

--- a/ivy.xml
+++ b/ivy.xml
@@ -21,7 +21,7 @@
   <dependency org="com.yahoo.platform.yui" name="yuicompressor" rev="2.4.2-zimbra"/>
   <dependency org="rhino" name="js" rev="1.6R7"/>
   <dependency org="zimbra" name="zm-soap" rev="latest.integration"/>
-  <dependency org="zimbra" name="zm-ajax" rev="latest.integration"/>
+  <dependency org="zimbra" name="zm-admin-ajax" rev="latest.integration"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration"/>
   <dependency org="zimbra" name="zm-client" rev="latest.integration"/>
   <dependency org="zimbra" name="zm-store" rev="latest.integration"/>


### PR DESCRIPTION
ZCS-1326: Create separate versions of zm-ajax for zm-web-client & zm-admin-console

Description: Changes to use zm-admin-ajax instead of zm-ajax.

Changeset:
* build.xml:
  * Updating references to point to zm-admin-ajax, instead of zm-ajax.
  * Removing obsolete target build-ajax.
 * ivy.xml: Updating dependency to use zm-admin-ajax.
 * Renaming Readme.txt to Readme.md to support markdown syntax.
 * Updating Readme file to document zm-admin-ajax instead of zm-ajax.