### PR TITLE
Fixing wrong sequences of two apostrophe characters in the French

### DIFF
--- a/WebRoot/messages/ZaMsg_fr.properties
+++ b/WebRoot/messages/ZaMsg_fr.properties
@@ -278,7 +278,7 @@ NAD_AddAllowedIP = Ajouter IP autoris\u00e9e
 NAD_RemoveVirtualHost = Supprimer
 Domain_VH_Explanation = Les h\u00f4tes virtuels permettent au syst\u00e8me de d\u00e9finir un domaine par d\u00e9faut pour \
 chaque utilisateur.  Tout utilisateur qui se connecte \u00e0 une URL en sp\u00e9cifiant \
-l''un des noms d''''h\u00f4te ci-dessous est consid\u00e9r\u00e9 comme \u00e9voluant dans ce domaine, {0}. \
+l''un des noms d''h\u00f4te ci-dessous est consid\u00e9r\u00e9 comme \u00e9voluant dans ce domaine, {0}. \
 Remarque\u00a0: la suppression d''un h\u00f4te virtuel prend effet seulement apr\u00e8s red\u00e9marrage du serveur de messagerie. 
 Domain_BC_ShareConf = Configuration du partage du porte-documents
 Notebook_Access_Control = Contr\u00f4le d'acc\u00e8s aux documents  


### PR DESCRIPTION
localization.

Same sort of fix as in  [this pull request](https://github.com/Zimbra/zm-web-client/pull/99)