### PR TITLE
ZCS-2756: Domain admin is unable to view domain list, ZCS-2757: domain list view is blank when DA has 'AdminConsoleCosRights' on global target

### DIFF
--- a/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
+++ b/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
@@ -1308,8 +1308,8 @@ ZaZimbraAdmin.isGlobalAdmin = function () {
 ZaZimbraAdmin.hasGlobalDomainListAccess = function () {
     return (ZaZimbraAdmin.isGlobalAdmin() || 
             (ZaSettings.targetRights[ZaItem.DOMAIN] 
-                && ZaSettings.targetRights[ZaItem.DOMAIN][ZaCos.RIGHT_LIST_DOMAIN] 
-                && ZaSettings.targetRights[ZaItem.DOMAIN][ZaCos.RIGHT_LIST_DOMAIN].some));
+                && ZaSettings.targetRights[ZaItem.DOMAIN][ZaDomain.RIGHT_LIST_DOMAIN]
+                && ZaSettings.targetRights[ZaItem.DOMAIN][ZaDomain.RIGHT_LIST_DOMAIN].some));
 }
 
 ZaZimbraAdmin.hasGlobalCOSSListAccess = function () {

--- a/WebRoot/js/zimbraAdmin/config/settings/ZaSettings.js
+++ b/WebRoot/js/zimbraAdmin/config/settings/ZaSettings.js
@@ -147,7 +147,7 @@ ZaSettings.initGlobalRightsFromJS = function(resp) {
 		}
 	}	
 	ZaApp.getInstance()._cosNameList = cosNameList;
-	ZaApp.getInstance()._domainNameList = domainNamelist;
+	ZaApp.getInstance()._domainNameList = domainNameList;
 }
 
 ZaSettings.parseTargetsRightsFromJS = function(targetObj) {

--- a/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainListController.js
+++ b/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainListController.js
@@ -847,5 +847,4 @@ ZaDomainListController.prototype.searchCallback = function(params, resp) {
 	ZaListViewController.prototype.searchCallback.call(this, params, resp);
 	var app = ZaApp.getInstance();
 	app._domainList = this.getList();
-	app._domainNameList = undefined;
 };


### PR DESCRIPTION
ZCS-2756: Domain admin is unable to view domain list
ZCS-2757: domain list view is blank when DA has 'AdminConsoleCosRights' on global target

Root cause: 
* `ZaZimbraAdmin.hasGlobalDomainListAccess()` was checking rights  using ZaCos object which is not having RIGHT_LIST_DOMAIN attribute.

Fix Description:
* Fixing check for rights check for domain to check ZaDomain object for RIGHT_LIST_DOMAIN permission.