### PR TITLE
ZCS-2968 "Enable S/MIME public key encryption and signing" cannot be shown on delegated admin

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/Super_XFormItems.js
+++ b/WebRoot/js/zimbraAdmin/common/Super_XFormItems.js
@@ -615,8 +615,7 @@ Super_Checkbox_XFormItem.prototype.initializeItems = function() {
 		},
 		trueValue:this.getInheritedProperty("trueValue"),
 		falseValue:this.getInheritedProperty("falseValue"),
-		forceUpdate:true,
-
+		forceUpdate:true
 	};
 	var chkBoxElementChanged = this.getInheritedProperty("checkBoxElementChanged");
 	if(chkBoxElementChanged) {

--- a/WebRoot/js/zimbraAdmin/common/Super_XFormItems.js
+++ b/WebRoot/js/zimbraAdmin/common/Super_XFormItems.js
@@ -603,7 +603,8 @@ Super_Checkbox_XFormItem.prototype.colSizes = ["275px","225px","*"];
 Super_Checkbox_XFormItem.prototype.initializeItems = function() {
 	var anchorCssStyle = this.getInheritedProperty("anchorCssStyle");
 	var checkboxSubLabel = this.getInheritedProperty("checkboxSubLabel");
-    var checkLabelCssClass = this.getInheritedProperty("labelCssClass");
+	var checkLabelCssClass = this.getInheritedProperty("labelCssClass");
+	var clearChildComponentChecks = this.getInheritedProperty("clearChildComponentChecks");
 
 	var chkBox = {
 		type:_CHECKBOX_, ref:".",  labelCssClass:checkLabelCssClass, subLabel:checkboxSubLabel,
@@ -614,7 +615,8 @@ Super_Checkbox_XFormItem.prototype.initializeItems = function() {
 		},
 		trueValue:this.getInheritedProperty("trueValue"),
 		falseValue:this.getInheritedProperty("falseValue"),
-		forceUpdate:true
+		forceUpdate:true,
+
 	};
 	var chkBoxElementChanged = this.getInheritedProperty("checkBoxElementChanged");
 	if(chkBoxElementChanged) {
@@ -660,7 +662,14 @@ Super_Checkbox_XFormItem.prototype.initializeItems = function() {
 	this.items = [chkBox,anchorHlpr];
 
 	Composite_XFormItem.prototype.initializeItems.call(this);
-}	
+
+	if(clearChildComponentChecks) {
+		this.items.forEach(function(item) {
+			item.visibilityChecks = [];
+			item.enableDisableChecks = [];
+		});
+	}
+}
 
 Super_Checkbox_XFormItem.prototype.items = []; 
 


### PR DESCRIPTION
- introduce way to clear visibility/disability checks on individual elements when composite element has those checks already defined