### PR TITLE
ZCS-3042 Removed noWrap from ZaXDialog.

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/ZaXDialog.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaXDialog.js
@@ -310,7 +310,6 @@ function () {
 	col2 = row2.insertCell(row2.cells.length);
 	col2.align = "left";
 	col2.vAlign = "middle";
-	col2.noWrap = true;
     if (this._contentW)
 	    col2.width = this._contentW;
 	col2.appendChild(this._pageDiv);


### PR DESCRIPTION
 ZCS-3042 NoWrap prevents text to automatically fit to parent div stretching it.