### PR TITLE
ZCS-3487 zimbraHelpAdminURL not working when set in global config

### DIFF
--- a/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
+++ b/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
@@ -790,19 +790,32 @@ ZaZimbraAdmin.prototype._helpListener =
 function(ev) {
     //DBG.println(AjxDebug.DBG1, "Help is clicked ...") ;
     var acctName = ZaZimbraAdmin.currentUserLogin;
-    var domainName = acctName.split('@')[1];
-    var domain = ZaDomain.getDomainByName(domainName);
     var curAcct = ZaZimbraAdmin.currentAdminAccount;
-    if(curAcct && domain) {
+
+    if(curAcct) {
         var url = null;
-        if(curAcct.attrs[ZaAccount.A_zimbraIsAdminAccount] == "TRUE")
-            url = domain.attrs[ZaDomain.A_zimbraHelpAdminURL];
-        else url = domain.attrs[ZaDomain.A_zimbraHelpDelegatedURL];
+        var prop = (curAcct.attrs[ZaAccount.A_zimbraIsAdminAccount] == "TRUE") ? "A_zimbraHelpAdminURL" : "A_zimbraHelpDelegatedURL";
+
+        var domainName = acctName.split('@')[1];
+        var domain = ZaDomain.getDomainByName(domainName);
+        var config = ZaApp.getInstance().getGlobalConfig();
+
+        // Check first on domain level
+        if(domain) {
+            url = domain.attrs[ZaDomain[prop]];
+        }
+
+        // Check in global config
+        if(!url && config) {
+            url = config.attrs[ZaGlobalConfig[prop]];
+        }
+
         if(url) {
-                window.open(url);
-                return;
+            window.open(url);
+            return;
         }
     }
+
     //skin takes the zimbraHelpAdminURL and put it into the skin hints
     var helpButton = skin && skin.hints && skin.hints.helpButton;      
     if (helpButton && helpButton.url) {


### PR DESCRIPTION
- When zimbraHelpAdminURL is set in global config, admin console was ignoring that value
- Add code to get url value from global config also if it is not set at domain level