### PR TITLE
MTA mail queue console: column with source domain not filled with data

### DIFF
--- a/WebRoot/js/zimbraAdmin/mta/view/ZaQMessagesListView.js
+++ b/WebRoot/js/zimbraAdmin/mta/view/ZaQMessagesListView.js
@@ -88,6 +88,11 @@ function(item) {
 				html[idx++] = "<td align=left height=20px width=" + this._headerList[i]._width + ">";
 				html[idx++] =item[ZaMTAQMsgItem.A_origin_ip];
 				html[idx++] = "</td>";
+			} else if(field == ZaMTAQMsgItem.A_fromdomain) {
+				// name
+				html[idx++] = "<td align=left height=20px width=" + this._headerList[i]._width + ">";
+				html[idx++] =item[ZaMTAQMsgItem.A_fromdomain];
+				html[idx++] = "</td>";
 			}			
 		}
 	} else {


### PR DESCRIPTION
Column displaying source domain data in the message summary not
populated at all. Fixed.