### PR TITLE
MTA Mail queue console: removed extra header column

### DIFF
--- a/WebRoot/js/zimbraAdmin/mta/view/ZaMTAXFormView.js
+++ b/WebRoot/js/zimbraAdmin/mta/view/ZaMTAXFormView.js
@@ -547,7 +547,6 @@ ZaMTAXFormView.myXFormModifier = function(xFormObject) {
 	msgHeaderList[5] = new ZaListHeaderItem(ZaMTAQMsgItem.A_fromdomain, ZaMsg.PQV_origin_domain_col, null, "106px", null, null, true, true);
 	msgHeaderList[6] = new ZaListHeaderItem(ZaMTAQMsgItem.A_content_filter, ZaMsg.PQV_content_filter_col, "103px", null, null, null, true, true);
 	msgHeaderList[7] = new ZaListHeaderItem(ZaMTAQMsgItem.A_time, ZaMsg.PQV_time_col, null, "78px", null, null, true, true);
-	msgHeaderList[8] = new ZaListHeaderItem(null, null, null, "auto", null, null, true, true);
 
 	xFormObject.items = [
 		{type:_GROUP_, cssClass:"ZmSelectedHeaderBg", colSpan:"*", id:"xform_header", 


### PR DESCRIPTION
The table displaying the summary of messages in the mail queue
management console has got 9 columns in the header row and 8 in the data
rows.
Removed the trailing column in the header row since it skews alignment
and handling of the table in general