### PR TITLE
ZBUG-830: removed millisec from timestamp before parsing it

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/ZaItem.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaItem.js
@@ -1098,6 +1098,8 @@ ZaItem.adminHasAnyRight = function (rights) {
 
 ZaItem.formatServerTime = function(serverStr) {
 	if(serverStr) {
+		var regex = /(\d{14})\.\d{3}Z/;
+		serverStr = serverStr.replace(regex, '$1Z');
 		var ajxTKServerStr = serverStr.substring(0,8) + "T" + serverStr.substring(8) ;
 		var curDate = AjxDateUtil.parseServerDateTime(ajxTKServerStr);	
         var formatter = AjxDateFormat.getDateTimeInstance(AjxDateFormat.LONG) ;


### PR DESCRIPTION
**Background:**
- When zimbraLdapGentimeFractionalSecondsEnabled is TRUE, timestamp like zimbraCreateTimestamp is saved in "yyyyMMddHHmmss.SSSZ" format.
- When zimbraLdapGentimeFractionalSecondsEnabled is FALSE, timestamp is saved in "yyyyMMddHHmmss.Z" format.

**Problem:**
If a timestamp has millisecond, datetime is shown without considering client's timezone on Admin Console. (i.e. it is always shown in UTC.)

**Route Cause:**
Timestamp was parsed in the following way:

    ZaItem.formatServerTime = function(serverStr) {
        if(serverStr) {
            var ajxTKServerStr = serverStr.substring(0,8) + "T" + serverStr.substring(8) ;
            var curDate = AjxDateUtil.parseServerDateTime(ajxTKServerStr);    
            var formatter = AjxDateFormat.getDateTimeInstance(AjxDateFormat.LONG) ;
                return formatter.format(curDate) ;
        } else {
            return "";
        }    
    }

It didn't consider millisecond. If timestamp had millisecond, ajxTKServerStr became a wrong value.

**Fix:**
Remove milliseconds from timestamp before it is parsed.

**Affected attributes:**
- zimbraCreateTimestamp
- zimbraLastLogonTimestamp
- zimbraVersionCheckLastAttempt
- zimbraVersionCheckLastSuccess