### PR TITLE
ZCS-8441 : Upgrading yui version 

### DIFF
--- a/WebRoot/public/admin.jsp
+++ b/WebRoot/public/admin.jsp
@@ -192,13 +192,13 @@
 </style>
 
 <c:set var="contextPath" value="${pageContext.request.contextPath}"/>
-<script type="text/javascript" src="${contextPath}/yui/2.7.0/yahoo-dom-event/yahoo-dom-event.js"></script> 
-<script type="text/javascript" src="${contextPath}/yui/2.7.0/element/element-min.js"></script> 
-<script type="text/javascript" src="${contextPath}/yui/2.7.0/datasource/datasource-min.js"></script> 
-<script type="text/javascript" src="${contextPath}/yui/2.7.0/json/json-min.js"></script> 
-<script type="text/javascript" src="${contextPath}/yui/2.7.0/charts/charts-min.js"></script> 
+<script type="text/javascript" src="${contextPath}/yui/2.9.0-alfresco-20141223/yahoo-dom-event/yahoo-dom-event.js"></script> 
+<script type="text/javascript" src="${contextPath}/yui/2.9.0-alfresco-20141223/element/element-min.js"></script> 
+<script type="text/javascript" src="${contextPath}/yui/2.9.0-alfresco-20141223/datasource/datasource-min.js"></script> 
+<script type="text/javascript" src="${contextPath}/yui/2.9.0-alfresco-20141223/json/json-min.js"></script> 
+<script type="text/javascript" src="${contextPath}/yui/2.9.0-alfresco-20141223/charts/charts-min.js"></script> 
 <script type="text/javascript">
-    YAHOO.widget.Chart.SWFURL = "yui/2.7.0/charts/assets/charts.swf";
+    YAHOO.widget.Chart.SWFURL = "yui/2.9.0-alfresco-20141223/charts/assets/charts.swf";
 </script>
 
 <jsp:include page="Boot.jsp"/>

--- a/build.xml
+++ b/build.xml
@@ -87,7 +87,7 @@
     <property name="3rdparty.dir" value="${build.js.dir}/ajax/3rdparty" />
 
     <property name="modernizr.version" value="2.8.3"/>
-    <property name="yui.version" value="2.7.0"/>
+    <property name="yui.version" value="2.9.0-alfresco-20141223"/>
     <property name="jquery.version" value="1.11.0"/>
 
 	<!-- customize admin skin -->
@@ -140,7 +140,7 @@
         <property name='build.admin' value='true'/>
         <property name='deploy.app' value='zimbraAdmin'/>
         <property name='skins.dir' value='${web.dir}/admin_skins'/>
-        <property name='web.includes' value='${common.web.includes},yui/2.7.0/**'/>
+        <property name='web.includes' value='${common.web.includes},yui/2.9.0-alfresco-20141223/**'/>
         <property name='web.excludes' value='${common.web.excludes}'/>
         <property name='jsp.includes' value='${common.jsp.includes}'/>
         <property name='jsp.excludes' value='${common.jsp.excludes}'/>

--- a/build.xml
+++ b/build.xml
@@ -88,7 +88,6 @@
 
     <property name="modernizr.version" value="2.8.3"/>
     <property name="yui.version" value="2.9.0-alfresco-20141223"/>
-    <property name="jquery.version" value="1.11.0"/>
 
 	<!-- customize admin skin -->
 	<if>
@@ -195,7 +194,6 @@
             </preserveintarget>
         </sync>
 
-        <antcall target="jquery" />
         <antcall target="modernizr" />
         <antcall target="yui" />
     </target>
@@ -1374,17 +1372,6 @@ ext = BeanUtils.cook(ext);
             <fileset dir="${jspc.src.dir}" />
             <fileset dir="${jspc.build.dir}" />
         </delete>
-    </target>
-
-    <!-- JQUERY Library -->
-    <target name="jquery" depends="resolve">
-        <ivy:install organisation="org.webjars" module="jquery" revision="${jquery.version}" settingsRef="dev.settings" from="chain-resolver" to="build-tmp" overwrite="true" transitive="true" />
-
-        <unzip src="${build.tmp.dir}/jquery-${jquery.version}.jar" dest="${build.tmp.dir}/jquery" overwrite="true" />
-
-        <copy todir="${3rdparty.dir}/jquery">
-            <fileset dir="${build.tmp.dir}/jquery/META-INF/resources/webjars/jquery/${jquery.version}" />
-        </copy>
     </target>
 
     <!-- MODERNIZR Library -->


### PR DESCRIPTION
ZCS-8441 : upgrading yui version from 2.7.0 to 2.9.0-alfresco-20141223 to avoid vulnerabilities where it has been downloaded from 
https://mvnrepository.com/artifact/com.yahoo.platform.yui/yui/2.9.0-alfresco-20141223 where this is the latest amongst 2.9.0.
default 2.9.0 doesnot has any zip 
And Removing jquery related code has not required :  (https://jira.corp.synacor.com/browse/ZCS-8012 )
