### PR TITLE
Typo fix: getHisotryMgr() -> getHistoryMgr()

### DIFF
--- a/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
+++ b/WebRoot/js/zimbraAdmin/ZaZimbraAdmin.js
@@ -1028,7 +1028,7 @@ function() {
         
 }
 
-ZaZimbraAdmin.prototype.getHisotryMgr =
+ZaZimbraAdmin.prototype.getHistoryMgr =
 function() {
     return this._historyMgr;
 }

--- a/WebRoot/js/zimbraAdmin/common/ZaCrtAppTreeHeader.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaCrtAppTreeHeader.js
@@ -32,7 +32,7 @@ ZaCrtAppTreeHeader = function(parent, className, buttons) {
     var cssClass = className || "ZaCtrAppTreeHeader";
 	DwtButton.call(this, parent, "", cssClass, Dwt.ABSOLUTE_STYLE);
     this.preObj = null;
-	this._historyMgr = ZaZimbraAdmin.getInstance().getHisotryMgr();
+	this._historyMgr = ZaZimbraAdmin.getInstance().getHistoryMgr();
     this._historyMgr.addChangeListener(new AjxListener(this, this.updateMenu));
     this.menu = new ZaPopupMenu(this);
     this.menu.setWidth(150);

--- a/WebRoot/js/zimbraAdmin/common/ZaOverviewPanelController.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaOverviewPanelController.js
@@ -1787,7 +1787,7 @@ ZaOverviewPanelController.prototype.addObjectItem = function(parentPath, name, c
     }
 
     var historyObject = new ZaHistory(namePath, name, relatedZaItem ? relatedZaItem.type : null);
-    ZaZimbraAdmin.getInstance().getHisotryMgr().addHistoryObj(historyObject);
+    ZaZimbraAdmin.getInstance().getHistoryMgr().addHistoryObj(historyObject);
 
     if (needToAddNameNode) {
         var parentDataItem = tree.getTreeItemDataByPath(parentPath);
@@ -1928,7 +1928,7 @@ ZaOverviewPanelController.prototype.getRelatedList = function(parentPath, item) 
 }
 
 ZaOverviewPanelController.prototype.getRecentList = function() {
-    var historyMgr = ZaZimbraAdmin.getInstance().getHisotryMgr();
+    var historyMgr = ZaZimbraAdmin.getInstance().getHistoryMgr();
     var objList = historyMgr.getAllHistoryObj().getArray();
     var Tis = [];
     var ti = null;

--- a/WebRoot/js/zimbraAdmin/common/ZaTree.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaTree.js
@@ -620,7 +620,7 @@ function (dataItem) {
 
 
     var historyObject = new ZaHistory(path, text, type);
-    var historyMgr = ZaZimbraAdmin.getInstance().getHisotryMgr();
+    var historyMgr = ZaZimbraAdmin.getInstance().getHistoryMgr();
     historyMgr.addHistoryObj(historyObject);
     var objList = historyMgr.getAllHistoryObj().getArray();
     var ti = null;


### PR DESCRIPTION
Fixing a typo in the method name