### PR TITLE
ZBUG-1556 : Fix Ephemeral BackendURL issue.

### DIFF
--- a/WebRoot/js/zimbraAdmin/globalconfig/controller/ZaGlobalConfigViewController.js
+++ b/WebRoot/js/zimbraAdmin/globalconfig/controller/ZaGlobalConfigViewController.js
@@ -416,6 +416,11 @@ function () {
 					isIPOrHostName = false;
 				}
 
+				// In case of localhost, lets not verify IPV4
+				if (chunks[1] === 'localhost') {
+					isIPOrHostName = true;
+				}
+
 				if (!isIPOrHostName) {
 					try {
 						var exIPData = ZaIPUtil.isIPV4(chunks[1]);


### PR DESCRIPTION
Consider localhost as valid url.
And don't proceed to verify valid IPV4 in case of localhost.