### PR TITLE
ZCS-10415 : Allow admin to configure disallowed attachment types.

### DIFF
--- a/WebRoot/js/zimbraAdmin/accounts/controller/ZaAccountViewController.js
+++ b/WebRoot/js/zimbraAdmin/accounts/controller/ZaAccountViewController.js
@@ -382,6 +382,21 @@ function () {
 		}
 	}
 
+	//check if blocked extensions are changed
+	if(ZaItem.hasWritePermission(ZaAccount.A_zimbraFileUploadBlockedFileTypes,tmpObj)) {
+		if(!AjxUtil.isEmpty(tmpObj.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes])) {
+			if((
+					((!this._currentObject.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes] || !this._currentObject.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes].length))
+					|| (tmpObj.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes] != this._currentObject.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes]))
+					&& !(tmpObj.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes] instanceof Array)
+				) {
+				mods[ZaAccount.A_zimbraFileUploadBlockedFileTypes] = tmpObj.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes].split(',');
+			}
+		} else if (AjxUtil.isEmpty(tmpObj.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes])  && !AjxUtil.isEmpty(this._currentObject.attrs[ZaAccount.A_zimbraFileUploadBlockedFileTypes])) {
+			mods[ZaAccount.A_zimbraFileUploadBlockedFileTypes] = "";
+		}
+	}
+
 	if(ZaTabView.isTAB_ENABLED(this._currentObject,ZaAccountXFormView.SKIN_TAB_ATTRS, ZaAccountXFormView.SKIN_TAB_RIGHTS)) {
 		if(tmpObj.attrs[ZaAccount.A_zimbraAvailableSkin] != null) {
 			if(!(tmpObj.attrs[ZaAccount.A_zimbraAvailableSkin] instanceof Array)) {

--- a/WebRoot/js/zimbraAdmin/accounts/model/ZaAccount.js
+++ b/WebRoot/js/zimbraAdmin/accounts/model/ZaAccount.js
@@ -112,6 +112,10 @@ ZaAccount.A_zimbraContactMaxNumEntries = "zimbraContactMaxNumEntries";
 ZaAccount.A_zimbraMailForwardingAddressMaxLength = "zimbraMailForwardingAddressMaxLength";
 ZaAccount.A_zimbraMailForwardingAddressMaxNumAddrs = "zimbraMailForwardingAddressMaxNumAddrs";
 ZaAccount.A_zimbraAttachmentsBlocked = "zimbraAttachmentsBlocked";
+ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled = "zimbraFeatureFileTypeUploadRestrictionsEnabled";
+ZaAccount.A_zimbraFileUploadBlockedFileTypes = "zimbraFileUploadBlockedFileTypes";
+ZaAccount.A_zimbraMailAttachmentMaxSize = "zimbraMailAttachmentMaxSize";
+ZaAccount.A_zimbraFileUploadMaxSizePerFile = "zimbraFileUploadMaxSizePerFile";
 ZaAccount.A_zimbraQuotaWarnPercent = "zimbraQuotaWarnPercent";
 ZaAccount.A_zimbraQuotaWarnInterval = "zimbraQuotaWarnInterval";
 ZaAccount.A_zimbraQuotaWarnMessage = "zimbraQuotaWarnMessage";
@@ -1907,6 +1911,10 @@ ZaAccount.myXModel = {
         {id:ZaAccount.A_zimbraProxyAllowedDomains, type:_COS_LIST_, ref:"attrs/"+ZaAccount.A_zimbraProxyAllowedDomains, listItem:{ type: _STRING_}},
         {id:ZaAccount.A_zimbraMailForwardingAddressMaxNumAddrs, type:_COS_NUMBER_, ref:"attrs/"+ZaAccount.A_zimbraMailForwardingAddressMaxNumAddrs, maxInclusive:2147483647, minInclusive:0},
         {id:ZaAccount.A_zimbraAttachmentsBlocked, type:_COS_ENUM_, ref:"attrs/"+ZaAccount.A_zimbraAttachmentsBlocked, choices:ZaModel.BOOLEAN_CHOICES},
+        {id:ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, type:_COS_ENUM_, ref:"attrs/"+ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, choices:ZaModel.BOOLEAN_CHOICES},
+        {id:ZaAccount.A_zimbraFileUploadBlockedFileTypes, type:_COS_STRING_, ref:"attrs/" + ZaAccount.A_zimbraFileUploadBlockedFileTypes},
+        {id:ZaAccount.A_zimbraMailAttachmentMaxSize, ref:"attrs/" + ZaAccount.A_zimbraMailAttachmentMaxSize, type: _COS_NUMBER_},
+        {id:ZaAccount.A_zimbraFileUploadMaxSizePerFile, ref:"attrs/" + ZaAccount.A_zimbraFileUploadMaxSizePerFile, type: _COS_NUMBER_},
 
         {id:ZaAccount.A_zimbraQuotaWarnPercent, type:_COS_NUMBER_, ref:"attrs/" + ZaAccount.A_zimbraQuotaWarnPercent},
         {id:ZaAccount.A_zimbraQuotaWarnInterval, type:_COS_MLIFETIME_, ref:"attrs/"+ZaAccount.A_zimbraQuotaWarnInterval},

--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
@@ -1244,7 +1244,11 @@ ZaAccountXFormView.ADVANCED_TAB_ATTRS = [ZaAccount.A_zimbraAttachmentsBlocked,
     ZaAccount.A_zimbraMailDumpsterLifetime,
     ZaAccount.A_zimbraFreebusyExchangeUserOrg,
     ZaAccount.A_zimbraMailCanonicalAddress,
-    ZaAccount.A_zimbraMailTransport
+    ZaAccount.A_zimbraMailTransport,
+    ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled,
+    ZaAccount.A_zimbraFileUploadBlockedFileTypes,
+    ZaAccount.A_zimbraMailAttachmentMaxSize,
+    ZaAccount.A_zimbraFileUploadMaxSizePerFile
     ];
 ZaAccountXFormView.ADVANCED_TAB_RIGHTS = [];
 
@@ -3155,13 +3159,38 @@ textFieldCssClass:"admin_xform_number_input"}
                         {type:_ZA_TOP_GROUPER_, id:"account_attachment_settings",colSizes:["auto"],numCols:1,
                             label:ZaMsg.NAD_AttachmentsGrouper,
                             visibilityChecks:[[ZATopGrouper_XFormItem.isGroupVisible,
-                                    [ZaAccount.A_zimbraAttachmentsBlocked]]],
+                                    [ZaAccount.A_zimbraAttachmentsBlocked, ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, ZaAccount.A_zimbraFileUploadBlockedFileTypes, ZaAccount.A_zimbraMailAttachmentMaxSize, ZaAccount.A_zimbraFileUploadMaxSizePerFile]]],
                             items :[
                                 {ref:ZaAccount.A_zimbraAttachmentsBlocked, type:_SUPER_CHECKBOX_,
                                     resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
                                     msgName:ZaMsg.NAD_RemoveAllAttachments,
                                     checkBoxLabel:ZaMsg.NAD_RemoveAllAttachments,
                                     trueValue:"TRUE", falseValue:"FALSE"
+                                },
+                                {ref:ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled,
+                                    type:_SUPER_CHECKBOX_, resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    msgName:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                                    checkBoxLabel:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                                    trueValue:"TRUE", falseValue:"FALSE"
+                                },
+                                {ref:ZaAccount.A_zimbraFileUploadBlockedFileTypes, type:_SUPER_TEXTAREA_,
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    txtBoxLabel:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                                    msgName:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                                    labelCssStyle:"vertical-align:top;", textAreaWidth:"250px",
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS
+                                },
+                                {ref:ZaAccount.A_zimbraMailAttachmentMaxSize, type:_SUPER_TEXTFIELD_,
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    msgName:ZaMsg.LBL_zimbraMailAttachmentMaxSize,
+                                    txtBoxLabel:ZaMsg.LBL_zimbraMailAttachmentMaxSize, labelLocation:_LEFT_,
+                                    textFieldCssClass:"admin_xform_number_input"
+                                },
+                                {ref:ZaAccount.A_zimbraFileUploadMaxSizePerFile, type:_SUPER_TEXTFIELD_,
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    msgName:ZaMsg.LBL_FileUploadMaxSizePerFile,
+                                    txtBoxLabel:ZaMsg.LBL_FileUploadMaxSizePerFile, labelLocation:_LEFT_,
+                                    textFieldCssClass:"admin_xform_number_input"
                                 }
                             ]
                         },

--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaNewAccountXWizard.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaNewAccountXWizard.js
@@ -1951,7 +1951,8 @@ ZaNewAccountXWizard.myXFormModifier = function(xFormObject, entry) {
         ZaNewAccountXWizard.ADVANCED_STEP = ++this.TAB_INDEX;
         this.stepChoices.push({value:ZaNewAccountXWizard.ADVANCED_STEP, label:ZaMsg.TABT_Advanced});
         advancedCaseItems = [];
-        if(ZAWizTopGrouper_XFormItem.isGroupVisible(entry,[ZaAccount.A_zimbraAttachmentsBlocked],[])) {
+        if(ZAWizTopGrouper_XFormItem.isGroupVisible(entry,[ZaAccount.A_zimbraAttachmentsBlocked,
+            ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled,ZaAccount.A_zimbraFileUploadBlockedFileTypes, ZaAccount.A_zimbraMailAttachmentMaxSize, ZaAccount.A_zimbraFileUploadMaxSizePerFile],[])) {
             advancedCaseItems.push({type:_ZAWIZ_TOP_GROUPER_, id:"account_attachment_settings",colSizes:["auto"],numCols:1,
                             label:ZaMsg.NAD_AttachmentsGrouper,
                             items :[
@@ -1961,6 +1962,31 @@ ZaNewAccountXWizard.myXFormModifier = function(xFormObject, entry) {
                                     msgName:ZaMsg.NAD_RemoveAllAttachments,
                                     checkBoxLabel:ZaMsg.NAD_RemoveAllAttachments,
                                     trueValue:"TRUE", falseValue:"FALSE"
+                                },
+                                {ref:ZaAccount.A_zimbraFeatureFileTypeUploadRestrictionsEnabled,
+                                    type:_SUPER_CHECKBOX_, resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    msgName:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                                    checkBoxLabel:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                                    trueValue:"TRUE", falseValue:"FALSE"
+                                },
+                                {ref:ZaAccount.A_zimbraFileUploadBlockedFileTypes, type:_SUPER_TEXTAREA_,
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    txtBoxLabel:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                                    msgName:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                                    labelCssStyle:"vertical-align:top;", textAreaWidth:"250px",
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS
+                                },
+                                {ref:ZaAccount.A_zimbraMailAttachmentMaxSize, type:_SUPER_TEXTFIELD_,
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    msgName:ZaMsg.LBL_zimbraMailAttachmentMaxSize,
+                                    txtBoxLabel:ZaMsg.LBL_zimbraMailAttachmentMaxSize, labelLocation:_LEFT_,
+                                    textFieldCssClass:"admin_xform_number_input"
+                                },
+                                {ref:ZaAccount.A_zimbraFileUploadMaxSizePerFile, type:_SUPER_TEXTFIELD_,
+                                    resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
+                                    msgName:ZaMsg.LBL_FileUploadMaxSizePerFile,
+                                    txtBoxLabel:ZaMsg.LBL_FileUploadMaxSizePerFile, labelLocation:_LEFT_,
+                                    textFieldCssClass:"admin_xform_number_input"
                                 }
                             ]
                         });

--- a/WebRoot/js/zimbraAdmin/cos/controller/ZaCosController.js
+++ b/WebRoot/js/zimbraAdmin/cos/controller/ZaCosController.js
@@ -302,8 +302,20 @@ function () {
 	} else if(this._currentObject.attrs[ZaCos.A_zimbraZimletAvailableZimlets] != null) {
 		mods[ZaCos.A_zimbraZimletAvailableZimlets] = "";
 	}
-	
-		
+
+	//check if blocked extensions are changed
+	if(!AjxUtil.isEmpty(tmpObj.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes])) {
+		if((
+				((!this._currentObject.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes] || !this._currentObject.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes].length))
+				|| (tmpObj.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes] != this._currentObject.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes]))
+				&& !(tmpObj.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes] instanceof Array)
+			) {
+			mods[ZaCos.A_zimbraFileUploadBlockedFileTypes] = tmpObj.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes].split(',');
+		}
+	} else if (AjxUtil.isEmpty(tmpObj.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes])  && !AjxUtil.isEmpty(this._currentObject.attrs[ZaCos.A_zimbraFileUploadBlockedFileTypes])) {
+		mods[ZaCos.A_zimbraFileUploadBlockedFileTypes] = "";
+	}
+
 	//check if need to rename
 	if(!isNew) {
 		if(tmpObj.name != this._currentObject.name) {

--- a/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
+++ b/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
@@ -59,6 +59,10 @@ ZaCos.A_zimbraPasswordBlockCommonEnabled = "zimbraPasswordBlockCommonEnabled";
 ZaCos.A_name = "cn";
 ZaCos.A_description = "description";
 ZaCos.A_zimbraAttachmentsBlocked = "zimbraAttachmentsBlocked";
+ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled = "zimbraFeatureFileTypeUploadRestrictionsEnabled";
+ZaCos.A_zimbraFileUploadBlockedFileTypes = "zimbraFileUploadBlockedFileTypes";
+ZaCos.A_zimbraMailAttachmentMaxSize = "zimbraMailAttachmentMaxSize";
+ZaCos.A_zimbraFileUploadMaxSizePerFile = "zimbraFileUploadMaxSizePerFile";
 ZaCos.A_zimbraQuotaWarnPercent = "zimbraQuotaWarnPercent";
 ZaCos.A_zimbraQuotaWarnInterval = "zimbraQuotaWarnInterval";
 ZaCos.A_zimbraQuotaWarnMessage = "zimbraQuotaWarnMessage";
@@ -646,6 +650,10 @@ ZaCos.myXModel = {
 //        {id:ZaCos.A_description, type:_STRING_, ref:"attrs/"+ZaCos.A_description},
         ZaItem.descriptionModelItem ,
         {id:ZaCos.A_zimbraAttachmentsBlocked, type:_ENUM_, choices:ZaModel.BOOLEAN_CHOICES, ref:"attrs/"+ZaCos.A_zimbraAttachmentsBlocked},
+        {id:ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, type:_ENUM_, ref:"attrs/"+ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, choices:ZaModel.BOOLEAN_CHOICES},
+        {id:ZaCos.A_zimbraFileUploadBlockedFileTypes, type:_STRING_, ref:"attrs/" + ZaCos.A_zimbraFileUploadBlockedFileTypes},
+        {id:ZaCos.A_zimbraMailAttachmentMaxSize, type:_NUMBER_, ref:"attrs/" + ZaCos.A_zimbraMailAttachmentMaxSize},
+        {id:ZaCos.A_zimbraFileUploadMaxSizePerFile, type: _NUMBER_, ref:"attrs/" + ZaCos.A_zimbraFileUploadMaxSizePerFile},
         {id:ZaCos.A_zimbraAuthTokenLifetime, type:_MLIFETIME_, ref:"attrs/"+ZaCos.A_zimbraAuthTokenLifetime, required: true},
         {id:ZaCos.A_zimbraAdminAuthTokenLifetime, type:_MLIFETIME_, ref:"attrs/"+ZaCos.A_zimbraAdminAuthTokenLifetime, required: true},
         {id:ZaCos.A_zimbraMailIdleSessionTimeout, type:_MINTERVAL_, ref:"attrs/"+ZaCos.A_zimbraMailIdleSessionTimeout},

--- a/WebRoot/js/zimbraAdmin/cos/view/ZaCosXFormView.js
+++ b/WebRoot/js/zimbraAdmin/cos/view/ZaCosXFormView.js
@@ -342,13 +342,16 @@ ZaCosXFormView.ADVANCED_TAB_ATTRS = [ZaCos.A_zimbraAttachmentsBlocked,
     ZaCos.A_zimbraMailDumpsterLifetime,
     ZaCos.A_zimbraDumpsterUserVisibleAge,
     ZaCos.A_zimbraFreebusyExchangeUserOrg,
-        ZaCos.A_zimbraDataSourcePop3PollingInterval,
-        ZaCos.A_zimbraDataSourceImapPollingInterval,
-        ZaCos.A_zimbraDataSourceCalendarPollingInterval,
-        ZaCos.A_zimbraDataSourceRssPollingInterval,
-        ZaCos.A_zimbraDataSourceCaldavPollingInterval,
-    ZaCos.A_zimbraDataSourceMinPollingInterval
-
+    ZaCos.A_zimbraDataSourcePop3PollingInterval,
+    ZaCos.A_zimbraDataSourceImapPollingInterval,
+    ZaCos.A_zimbraDataSourceCalendarPollingInterval,
+    ZaCos.A_zimbraDataSourceRssPollingInterval,
+    ZaCos.A_zimbraDataSourceCaldavPollingInterval,
+    ZaCos.A_zimbraDataSourceMinPollingInterval,
+    ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled,
+    ZaCos.A_zimbraFileUploadBlockedFileTypes,
+    ZaCos.A_zimbraMailAttachmentMaxSize,
+    ZaCos.A_zimbraFileUploadMaxSizePerFile
 ];
 ZaCosXFormView.ADVANCED_TAB_RIGHTS = [];
 
@@ -1469,9 +1472,31 @@ ZaCosXFormView.myXFormModifier = function(xFormObject, entry) {
         },
             {type:_ZA_TOP_GROUPER_, id:"cos_attachment_settings",
                 label:ZaMsg.NAD_AttachmentsGrouper,visibilityChecks:[[ZATopGrouper_XFormItem.isGroupVisible,
-                                                                      [ZaCos.A_zimbraAttachmentsBlocked]]],
+                                                                      [ZaCos.A_zimbraAttachmentsBlocked, ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, ZaCos.A_zimbraFileUploadBlockedFileTypes, ZaCos.A_zimbraMailAttachmentMaxSize, ZaCos.A_zimbraFileUploadMaxSizePerFile]]],
                 items :[
-                    {ref:ZaCos.A_zimbraAttachmentsBlocked, type:_CHECKBOX_,  msgName:ZaMsg.NAD_RemoveAllAttachments,label:ZaMsg.NAD_RemoveAllAttachments, labelLocation:_LEFT_, trueValue:"TRUE", falseValue:"FALSE",labelCssClass:"xform_label",  align:_LEFT_}
+                    {ref:ZaCos.A_zimbraAttachmentsBlocked, type:_CHECKBOX_,  msgName:ZaMsg.NAD_RemoveAllAttachments,label:ZaMsg.NAD_RemoveAllAttachments, labelLocation:_LEFT_, trueValue:"TRUE", falseValue:"FALSE",labelCssClass:"xform_label",  align:_LEFT_},
+                    {ref:ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, type:_CHECKBOX_,
+                        msgName:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                        label:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                        trueValue:"TRUE", falseValue:"FALSE"
+                    },
+                    {ref:ZaCos.A_zimbraFileUploadBlockedFileTypes, type:_TEXTAREA_,
+                        msgName:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                        label:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                        labelLocation:_LEFT_,
+                        labelCssStyle:"vertical-align:top;",
+                        width: "30em"
+                    },
+                    {ref:ZaCos.A_zimbraMailAttachmentMaxSize, type:_TEXTFIELD_,
+                        label:ZaMsg.LBL_zimbraMailAttachmentMaxSize,
+                        labelLocation:_LEFT_,
+                        cssClass:"admin_xform_number_input"
+                    },
+                    {ref:ZaCos.A_zimbraFileUploadMaxSizePerFile, type:_TEXTFIELD_,
+                        label:ZaMsg.LBL_FileUploadMaxSizePerFile,
+                        labelLocation:_LEFT_,
+                        cssClass:"admin_xform_number_input"
+                    }
                 ]
             },
             {type:_ZA_TOP_GROUPER_, id:"cos_quota_settings",

--- a/WebRoot/js/zimbraAdmin/cos/view/ZaNewCosXWizard.js
+++ b/WebRoot/js/zimbraAdmin/cos/view/ZaNewCosXWizard.js
@@ -440,13 +440,16 @@ ZaNewCosXWizard.ADVANCED_TAB_ATTRS = [ZaCos.A_zimbraAttachmentsBlocked,
     ZaCos.A_zimbraDumpsterUserVisibleAge,
     ZaCos.A_zimbraMailDumpsterLifetime,
     ZaCos.A_zimbraFreebusyExchangeUserOrg,
-        ZaCos.A_zimbraDataSourcePop3PollingInterval,
-        ZaCos.A_zimbraDataSourceImapPollingInterval,
-        ZaCos.A_zimbraDataSourceCalendarPollingInterval,
-        ZaCos.A_zimbraDataSourceRssPollingInterval,
-        ZaCos.A_zimbraDataSourceCaldavPollingInterval,
-    ZaCos.A_zimbraDataSourceMinPollingInterval
-
+    ZaCos.A_zimbraDataSourcePop3PollingInterval,
+    ZaCos.A_zimbraDataSourceImapPollingInterval,
+    ZaCos.A_zimbraDataSourceCalendarPollingInterval,
+    ZaCos.A_zimbraDataSourceRssPollingInterval,
+    ZaCos.A_zimbraDataSourceCaldavPollingInterval,
+    ZaCos.A_zimbraDataSourceMinPollingInterval,
+    ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled,
+    ZaCos.A_zimbraFileUploadBlockedFileTypes,
+    ZaCos.A_zimbraMailAttachmentMaxSize,
+    ZaCos.A_zimbraFileUploadMaxSizePerFile
 ];
 ZaNewCosXWizard.ADVANCED_TAB_RIGHTS = [];
 
@@ -1271,9 +1274,31 @@ ZaNewCosXWizard.myXFormModifier = function(xFormObject, entry) {
         },      
             {type:_ZAWIZ_TOP_GROUPER_, id:"cos_attachment_settings",
                 label:ZaMsg.NAD_AttachmentsGrouper,visibilityChecks:[[ZATopGrouper_XFormItem.isGroupVisible,
-                                                                      [ZaCos.A_zimbraAttachmentsBlocked]]],
+                                                                      [ZaCos.A_zimbraAttachmentsBlocked, ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, ZaCos.A_zimbraFileUploadBlockedFileTypes, ZaCos.A_zimbraMailAttachmentMaxSize, ZaCos.A_zimbraFileUploadMaxSizePerFile]]],
                 items :[
-                    {ref:ZaCos.A_zimbraAttachmentsBlocked, type:_WIZ_CHECKBOX_,  msgName:ZaMsg.NAD_RemoveAllAttachments,label:ZaMsg.NAD_RemoveAllAttachments, labelLocation:_LEFT_, trueValue:"TRUE", falseValue:"FALSE",labelCssClass:"xform_label",  align:_LEFT_}
+                    {ref:ZaCos.A_zimbraAttachmentsBlocked, type:_WIZ_CHECKBOX_,  msgName:ZaMsg.NAD_RemoveAllAttachments,label:ZaMsg.NAD_RemoveAllAttachments, labelLocation:_LEFT_, trueValue:"TRUE", falseValue:"FALSE",labelCssClass:"xform_label",  align:_LEFT_},
+                    {ref:ZaCos.A_zimbraFeatureFileTypeUploadRestrictionsEnabled, type:_CHECKBOX_,
+                        msgName:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                        label:ZaMsg.LBL_AttachmentRestrictionsEnabled,
+                        trueValue:"TRUE", falseValue:"FALSE"
+                    },
+                    {ref:ZaCos.A_zimbraFileUploadBlockedFileTypes, type:_TEXTAREA_,
+                        msgName:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                        label:ZaMsg.LBL_AttachmentBlockedFileTypes,
+                        labelLocation:_LEFT_,
+                        labelCssStyle:"vertical-align:top;",
+                        width: "30em"
+                    },
+                    {ref:ZaCos.A_zimbraMailAttachmentMaxSize, type:_TEXTFIELD_,
+                        label:ZaMsg.LBL_zimbraMailAttachmentMaxSize,
+                        labelLocation:_LEFT_,
+                        cssClass:"admin_xform_number_input"
+                    },
+                    {ref:ZaCos.A_zimbraFileUploadMaxSizePerFile, type:_TEXTFIELD_,
+                        label:ZaMsg.LBL_FileUploadMaxSizePerFile,
+                        labelLocation:_LEFT_,
+                        cssClass:"admin_xform_number_input"
+                    }
                 ]
             },
             {type:_ZAWIZ_TOP_GROUPER_, id:"cos_quota_settings",

--- a/WebRoot/messages/ZaMsg.properties
+++ b/WebRoot/messages/ZaMsg.properties
@@ -893,6 +893,10 @@ MSG_zimbraMailSignatureMaxLength = Maximum length of mail signature
 NAD_Attach_RemoveAttachmentsByExt = Reject messages with attachment extensions:
 NAD_Attach_NewExtension = New extension:
 NAD_Attach_AddExtension = Add
+LBL_AttachmentRestrictionsEnabled = Enable attachment upload restrictions
+LBL_AttachmentBlockedFileTypes = Restricted attachment file types
+LBL_zimbraMailAttachmentMaxSize = Maximum size in bytes for all attachments in an e-mail
+LBL_FileUploadMaxSizePerFile = Maximum size in bytes for each attachment
 
 Global_MTA_AuthenticationGrp = Authentication
 Global_MTA_NetworkGrp = Network


### PR DESCRIPTION
Added facility to alter these attributes.
zimbraFileUploadBlockedFileTypes - Commonly blocked file types for uploading.
zimbraFeatureFileTypeUploadRestrictionsEnabled - Enable/Disable blocked file types set in zimbraFileUploadBlockedFileTypes for uploading.
These attributes are availble at account and cos levels.