### PR TITLE
ZBUG-2457 : Fix 'Must change password' issue.

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/ZaAuthenticate.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaAuthenticate.js
@@ -53,7 +53,7 @@ function (uname,oldPass,newPass,callback) {
 }
 
 ZaAuthenticate.prototype.execute =
-function (uname, pword, twoFactorCode, trustedDevice, callback) {
+function (uname, pword, callback, twoFactorCode, trustedDevice) {
     var soapDoc = AjxSoapDoc.create("AuthRequest", ZaZimbraAdmin.URN, null);
     this.uname = uname;
     var params = new Object();

--- a/WebRoot/js/zimbraAdmin/common/ZaController.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaController.js
@@ -455,7 +455,7 @@ function(username, password, twoFactorCode, trustedDevice) {
         ZaZimbraAdmin.showSplash(this._shell);
         var callback = new AjxCallback(this, this.authCallback);
         this.auth = new ZaAuthenticate(this._appCtxt);
-        this.auth.execute(username, password, twoFactorCode, trustedDevice, callback);
+        this.auth.execute(username, password, callback, twoFactorCode, trustedDevice);
     } catch (ex) {
         if(ex.code == ZmCsfeException.NO_AUTH_TOKEN) {
             throw (ex);
@@ -634,7 +634,7 @@ function (resp) {
 /*********** Login dialog Callbacks */
 
 ZaController.prototype.loginCallback =
-function(uname, password, twoFactorCode, trustedDevice) {
+function(uname, password, newPassword, confPassword, twoFactorCode, trustedDevice) {
     //this._schedule(this._doAuth, {username: uname, password: password});
     this._doAuth(uname,password, twoFactorCode, trustedDevice);
 }
@@ -672,7 +672,7 @@ function(uname, oldPass, newPass, conPass) {
             ZaZimbraAdmin.showSplash(this._shell);
             var callback = new AjxCallback(this, this.authCallback);
             this.auth = new ZaAuthenticate(this._appCtxt);
-            this.auth.execute(uname, newPass,callback);
+            this.auth.execute(uname, newPass, callback);
         }
     } catch (ex) {
         ZaController.changePwdCommand = null;

--- a/WebRoot/js/zimbraAdmin/common/ZaLoginDialog.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaLoginDialog.js
@@ -205,7 +205,7 @@ function() {
 			trustedDevice = ZLoginFactory.get(ZLoginFactory.TRUST_DEVICE).value;
 		}
 		
-		this._callback.run(username, password, twoFactorCode, trustedDevice, newPassword,confPassword);		
+		this._callback.run(username, password, newPassword, confPassword, twoFactorCode, trustedDevice);		
 	}
 }
 


### PR DESCRIPTION
Must change password (zimbraPasswordMustChange) was not working due to JS error.
Parameter mismatch was the reason for the fatal JS errors.
Fix the parameters with different login scenarios.