### PR TITLE
ZCS-11022 : Fixed disabled username field.

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/ZaController.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaController.js
@@ -529,7 +529,6 @@ function (resp) {
         } else if(ex.code == ZmCsfeException.SVC_AUTH_EXPIRED) {
             this._showLoginDialog(true);
             this._loginDialog.setError(ZaMsg.ERROR_SESSION_EXPIRED);
-            this._loginDialog.disableUnameField(true);
             this._loginDialog.clearPassword();
         } else {
             if(this._msgDialog) {


### PR DESCRIPTION
Username field should not remain disabled when server throws AUTH_EXPIRED exception.
This issue surfaces with refactored admin 2fa flow on back-end.