### PR TITLE
ZBUG-2482 Fix issue with only displaying 15 results. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 build
+.gitignore
+.idea
 .classpath
 .project
 bin

--- a/WebRoot/js/zimbraAdmin/dl/model/ZaDistributionList.js
+++ b/WebRoot/js/zimbraAdmin/dl/model/ZaDistributionList.js
@@ -962,7 +962,7 @@ ZaDistributionList.prototype.pageAllMembers = function ( ) {
 	var names = AjxUtil.getHashKeys(allMembers); //sorted by name
 	for ( var i = 0; i < names.length ; i+= ZaDistributionList.MEMBER_LIST_PAGE_SIZE ) {
 		var page = new Array();
-		for ( var j = 0; (i + j < names.length) && (j < ZaDistributionList.MEMBER_LIST_PAGE_SIZE); j++ ) {
+		for ( var j = 0; (i + j < names.length); j++ ) {
 			var member = allMembers[ names[i+j] ];
 			page.push(member);
 		}


### PR DESCRIPTION
This fixes an issue with the distribution list model.

The array for DL members only displays 15. Attempts to add a new array result in an offset error.
This fix follows the same model as the search model. If the DL has too many members, we display a message saying that they must refine their search. DL lists which are too large should be handled via the CLI.