### PR TITLE
ZCS-11097 : Fix MustChangePassword issue with ChangePassword.

### DIFF
--- a/WebRoot/js/zimbraAdmin/accounts/controller/ZaAccountListController.js
+++ b/WebRoot/js/zimbraAdmin/accounts/controller/ZaAccountListController.js
@@ -1037,20 +1037,19 @@ function (item) {
                     }
 					ZaApp.getInstance().dialogs["errorMsgDlg"].setMessage(ZaMsg.ERROR_PASSWORD_TOOLONG+ "<br>" + maxpassMsg, null, DwtMessageDialog.CRITICAL_STYLE, null);
 					ZaApp.getInstance().dialogs["errorMsgDlg"].popup();
-				} else {		
+				} else {
+					if (this._chngPwdDlg.getMustChangePassword()) {
+						//item.attrs[ZaAccount.A_zimbraPasswordMustChange] = "TRUE";
+						var mods = new Object();
+						mods[ZaAccount.A_zimbraPasswordMustChange] = "TRUE";
+						item.modify(mods);
+					}
+
 					item.changePassword(szPwd);
 					this._chngPwdDlg.popdown();	//close the dialog
                     ZaApp.getInstance().getAppCtxt().getAppController().setActionStatusMsg(AjxMessageFormat.format(ZaMsg.PasswordModified,[item.name]));
 				}
-
 			}
-			if (this._chngPwdDlg.getMustChangePassword()) {
-				//item.attrs[ZaAccount.A_zimbraPasswordMustChange] = "TRUE";
-				var mods = new Object();
-				mods[ZaAccount.A_zimbraPasswordMustChange] = "TRUE";
-				item.modify(mods);
-			}
-
 		} catch (ex) {
 			if(ex.code == ZmCsfeException.ACCT_INVALID_PASSWORD ) {
 				var szMsg = ZaMsg.ERROR_PASSWORD_INVALID;


### PR DESCRIPTION
The issue occures due to a race condition between MustChangePassword and ChangePassword API calls.
Session gets invalidated once ChangePassword request gets processed before MustChangePassword call.
Changing the sequence and calling MustChangePassword first instead.