### PR TITLE
ZCS-12008: Compress Blobs and Compression threshold should not be visible on S3 Edit volume UI

### DIFF
--- a/WebRoot/js/zimbraAdmin/servers/view/ZaEditVolumeXDialog.js
+++ b/WebRoot/js/zimbraAdmin/servers/view/ZaEditVolumeXDialog.js
@@ -78,20 +78,28 @@ ZaEditVolumeXDialog.prototype.getMyXForm = function (params) {
 						label: ZaMsg.VM_VolumeCompressBlobs,
 						trueValue: true,
 						falseValue: false,
-						enableDisableChecks: !params || params.isVolumeTypeInternal,
+						visibilityChecks: [
+							function () {
+								return !params || params.isVolumeTypeInternal;
+							},
+						],
 					},
 					{
 						type: _GROUP_,
 						numCols: 3,
 						colSpan: 2,
 						colSizes: ["200px", "150px", "125px"],
+						visibilityChecks: [
+							function () {
+								return !params || params.isVolumeTypeInternal;
+							},
+						],
 						items: [
 							{
 								ref: ZaServer.A_VolumeCompressionThreshold,
 								type: _TEXTFIELD_,
 								label: ZaMsg.LBL_VM_VolumeCompressThreshold,
 								labelLocation: _LEFT_,
-								enableDisableChecks: !params || params.isVolumeTypeInternal,
 							},
 							{
 								type: _OUTPUT_,


### PR DESCRIPTION
This solution intends to hide the following internal-volume-specific fields when editing an external volume:
1. ZaServer.A_VolumeCompressBlobs
2. ZaServer.A_VolumeCompressionThreshold

The existing _enableDisableChecks_ attribute was replaced with _visibilityChecks_ for the mentioned fields.