### PR TITLE
ZCS-12396:Implemented dependency of compress blobs and compress threshold while adding and editing the internal volume

### DIFF
--- a/WebRoot/js/zimbraAdmin/servers/view/ZaEditVolumeXDialog.js
+++ b/WebRoot/js/zimbraAdmin/servers/view/ZaEditVolumeXDialog.js
@@ -75,7 +75,10 @@ ZaEditVolumeXDialog.prototype.getMyXForm = function (params) {
 					{
 						ref: ZaServer.A_VolumeCompressBlobs,
 						type: _WIZ_CHECKBOX_,
+						labelLocation: _LEFT_,
+						align: _LEFT_,
 						label: ZaMsg.VM_VolumeCompressBlobs,
+						labelCssStyle: "padding-left:25px;",
 						trueValue: true,
 						falseValue: false,
 						visibilityChecks: [
@@ -88,7 +91,7 @@ ZaEditVolumeXDialog.prototype.getMyXForm = function (params) {
 						type: _GROUP_,
 						numCols: 3,
 						colSpan: 2,
-						colSizes: ["200px", "150px", "125px"],
+						colSizes: ["140px", "100px", "*"],
 						visibilityChecks: [
 							function () {
 								return !params || params.isVolumeTypeInternal;
@@ -98,15 +101,17 @@ ZaEditVolumeXDialog.prototype.getMyXForm = function (params) {
 							{
 								ref: ZaServer.A_VolumeCompressionThreshold,
 								type: _TEXTFIELD_,
-								label: ZaMsg.LBL_VM_VolumeCompressThreshold,
+								label: ZaMsg.VM_VolumeCompressThreshold,
 								labelLocation: _LEFT_,
+								align: _LEFT_,
+								width: 100,
+								enableDisableChangeEventSources: [ZaServer.A_VolumeCompressBlobs],
+								enableDisableChecks: [[XForm.checkInstanceValue, ZaServer.A_VolumeCompressBlobs, true]],
 							},
 							{
 								type: _OUTPUT_,
-								label: null,
-								labelLocation: _NONE_,
-								value: ZaMsg.NAD_bytes,
-								align: _LEFT_,
+								label: ZaMsg.NAD_bytes,
+								labelCssStyle: "text-align:left;",
 							},
 						],
 					},


### PR DESCRIPTION
Implementation:
For admin console storage management tabs under server, implemented the following:

Compression blobs(CB) and compression threshold(CT) are dependent on each other i.e. the based on value of CB user will be able to edit the value of CT.
Its applicable only for internal Volumes while adding and editing.
If the value of CB is false the CT value displayed to the user would be "-"
If the value of CB is true the CT value displayed to the user would be one that is provided by the user.