### PR TITLE
ZCS-12966 Enable/Disable CountObjectsRequest with userAccount/account type on Zimbra WebAdmin

### DIFF
--- a/WebRoot/js/zimbraAdmin/globalconfig/model/ZaGlobalConfig.js
+++ b/WebRoot/js/zimbraAdmin/globalconfig/model/ZaGlobalConfig.js
@@ -44,6 +44,7 @@ ZaGlobalConfig.MTA_RESTRICTIONS = [
 //general
 ZaGlobalConfig.A_zimbraLastLogonTimestampFrequency = "zimbraLastLogonTimestampFrequency";
 ZaGlobalConfig.A_zimbraDefaultDomainName = "zimbraDefaultDomainName";
+ZaGlobalConfig.A_zimbraCountAccountsEnabled = "zimbraCountAccountsEnabled";
 ZaGlobalConfig.A_zimbraScheduledTaskNumThreads = "zimbraScheduledTaskNumThreads" ;
 ZaGlobalConfig.A_zimbraMailPurgeSleepInterval = "zimbraMailPurgeSleepInterval" ;
 		
@@ -463,6 +464,7 @@ ZaGlobalConfig.myXModel = {
             maxInclusive: 2147483647,
             defaultValue: 100
         },
+		{ id:ZaGlobalConfig.A_zimbraCountAccountsEnabled, ref:"attrs/" + ZaGlobalConfig.A_zimbraCountAccountsEnabled, type:_ENUM_, choices:ZaModel.BOOLEAN_CHOICES},
 		{ id:ZaGlobalConfig.A_zimbraDefaultDomainName, ref:"attrs/" + ZaGlobalConfig.A_zimbraDefaultDomainName, type:_STRING_, maxLength: 256},
 		{ id:ZaGlobalConfig.A_zimbraScheduledTaskNumThreads, ref:"attrs/" + ZaGlobalConfig.A_zimbraScheduledTaskNumThreads , type:_NUMBER_, minInclusive: 1 },
 		{ id:ZaGlobalConfig.A_zimbraMailPurgeSleepInterval, type:_MINTERVAL_, ref:"attrs/"+ZaGlobalConfig.A_zimbraMailPurgeSleepInterval},

--- a/WebRoot/js/zimbraAdmin/search/model/ZaSearch.js
+++ b/WebRoot/js/zimbraAdmin/search/model/ZaSearch.js
@@ -613,7 +613,7 @@ ZaSearch.getObjectCountsCalback = function(params, resp) {
         } else {
             var retObj;
             retObj = {};
-            retObj[ZaItem.ACCOUNT] = 0;
+            retObj[ZaItem.ACCOUNT] = "N/A";  // The value is not used as Integer in any code. String is acceptable.
             retObj[ZaItem.ALIAS] = 0;
             retObj[ZaItem.RESOURCE] = 0;
             retObj[ZaItem.DL] = 0;
@@ -628,6 +628,7 @@ ZaSearch.getObjectCountsCalback = function(params, resp) {
                     resp = batchResp.CountObjectsResponse[i];
                     var type = resp.type;
                     if (type == "userAccount") {
+                        // It is never processed because of the change on ZaSearch.getObjectCount
                         type = ZaItem.ACCOUNT; // UI only shows number of
                                                 // non-system accounts
                     }
@@ -653,11 +654,10 @@ ZaSearch.getObjectCounts = function(types, callback) {
     soapDoc.setMethodAttribute("onerror", "continue");
     for (var i = 0; i < types.length; i++) {
         var type = types[i];
-        var getCountDoc = soapDoc.set("CountObjectsRequest", null, null, ZaZimbraAdmin.URN);
-
         if (type == ZaItem.ACCOUNT) {
-            type = "userAccount"; // exclude system account
+            continue;
         }
+        var getCountDoc = soapDoc.set("CountObjectsRequest", null, null, ZaZimbraAdmin.URN);
         getCountDoc.setAttribute("type", type);
         if (ZaZimbraAdmin.isGlobalAdmin() === false && type == ZaItem.DOMAIN && ZaZimbraAdmin.currentAdminAccount.attrs[ZaAccount.A_zimbraIsDelegatedAdminAccount] === "TRUE") {
             getCountDoc.setAttribute("onlyRelated", "true");
@@ -670,6 +670,8 @@ ZaSearch.getObjectCounts = function(types, callback) {
         cmdParams.soapDoc = soapDoc;
         cmdParams.asyncMode = true;
         cmdParams.callback = dataCallback;
+        // BatchRequest with no element is sent when types array has ZaItem.ACCOUNT only.
+        // It is okay and easy way to pass default values to a callback function as a response via ZaSearch.getObjectCountsCalback.
         command.invoke(cmdParams);
     } catch (ex) {
         ZaApp.getInstance().getCurrentController()._handleException(ex, "ZaSearch.getObjectCounts", null, false);


### PR DESCRIPTION
**Problem:**
When millions of accounts exist on the system and CountObjectsRequest with userAccount type is sent from Admin Console to a server, it causes high load on a ldap server.

**Fix:**
Intoduced Ldap attr to enable/disable the counting of userAccount in CountObjectsRequest

**Test-cases:**

1. when zimbraCountObjectsEnabled is TRUE
send CountObjectsRequest with account or userAccount type.
show number of accounts in Home -> Summary -> Accounts and Manage -> left pane -> the number of accounts
2. when zimbraCountObjectsEnabled is FALSE
not to send CountObjectsRequest with account or userAccount type.
show N/A in Home -> Summary -> Accounts and Manage -> left pane -> the number of accounts