### PR TITLE
ZBUG-2871: Cant enable "reject common passwords"

### DIFF
--- a/WebRoot/js/zimbraAdmin/accounts/model/ZaAccount.js
+++ b/WebRoot/js/zimbraAdmin/accounts/model/ZaAccount.js
@@ -104,7 +104,6 @@ ZaAccount.A_zimbraPasswordMinDigitsOrPuncs = "zimbraPasswordMinDigitsOrPuncs";
 ZaAccount.A_zimbraMinPwdAge="zimbraPasswordMinAge";
 ZaAccount.A_zimbraMaxPwdAge="zimbraPasswordMaxAge";
 ZaAccount.A_zimbraEnforcePwdHistory="zimbraPasswordEnforceHistory";
-ZaAccount.A_zimbraPasswordBlockCommonEnabled="zimbraPasswordBlockCommonEnabled";
 ZaAccount.A_zimbraMailAlias="zimbraMailAlias";
 ZaAccount.A_zimbraMailForwardingAddress="zimbraMailForwardingAddress";
 ZaAccount.A_zimbraPasswordMustChange="zimbraPasswordMustChange";
@@ -1898,7 +1897,6 @@ ZaAccount.myXModel = {
         {id:ZaAccount.A_zimbraPrefCalendarForwardInvitesTo, type:_LIST_, ref:"attrs/"+ZaAccount.A_zimbraPrefCalendarForwardInvitesTo, listItem:{type:_EMAIL_ADDRESS_}},
         {id:ZaAccount.A_zimbraPasswordMustChange, type:_ENUM_, choices:ZaModel.BOOLEAN_CHOICES, ref:"attrs/"+ZaAccount.A_zimbraPasswordMustChange},
         {id:ZaAccount.A_zimbraPasswordLocked, type:_COS_ENUM_, ref:"attrs/"+ZaAccount.A_zimbraPasswordLocked, choices:ZaModel.BOOLEAN_CHOICES},
-        {id:ZaAccount.A_zimbraPasswordBlockCommonEnabled, type:_COS_ENUM_, ref:"attrs/"+ZaAccount.A_zimbraPasswordBlockCommonEnabled, choices:ZaModel.BOOLEAN_CHOICES},
         {id:ZaAccount.A_zimbraContactMaxNumEntries, type:_COS_NUMBER_, ref:"attrs/"+ZaAccount.A_zimbraContactMaxNumEntries, maxInclusive:2147483647, minInclusive:0},
         {id:ZaAccount.A_zimbraMailForwardingAddressMaxLength, type:_COS_NUMBER_, ref:"attrs/"+ZaAccount.A_zimbraMailForwardingAddressMaxLength, maxInclusive:2147483647, minInclusive:0},
         {id:ZaAccount.A_zimbraDataSourcePop3PollingInterval, type:_COS_MLIFETIME_, ref:"attrs/"+ZaAccount.A_zimbraDataSourcePop3PollingInterval},

--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
@@ -1225,7 +1225,6 @@ ZaAccountXFormView.ADVANCED_TAB_ATTRS = [ZaAccount.A_zimbraAttachmentsBlocked,
     ZaAccount.A_zimbraQuotaWarnInterval,
     ZaAccount.A_zimbraQuotaWarnMessage,
     ZaAccount.A_zimbraPasswordLocked,
-    ZaAccount.A_zimbraPasswordBlockCommonEnabled,
     ZaAccount.A_zimbraMinPwdLength,
     ZaAccount.A_zimbraMaxPwdLength,
     ZaAccount.A_zimbraPasswordMinUpperCaseChars,
@@ -3350,8 +3349,7 @@ textFieldCssClass:"admin_xform_number_input"}
                         			ZaAccount.A_zimbraPasswordMinDigitsOrPuncs,
                         			ZaAccount.A_zimbraMinPwdAge,
                         			ZaAccount.A_zimbraMaxPwdAge,
-                        			ZaAccount.A_zimbraEnforcePwdHistory,
-                        			ZaAccount.A_zimbraPasswordBlockCommonEnabled]]],
+                        			ZaAccount.A_zimbraEnforcePwdHistory]]],
 							items: [ 
 						                { type: _DWT_ALERT_, containerCssStyle: "padding-bottom:0;", colSpan:3,
 						                      style: DwtAlert.INFO,iconVisible: (!ZaAccountXFormView.isAuthfromInternal(entry.name)),
@@ -3435,13 +3433,6 @@ textFieldCssClass:"admin_xform_number_input"}
 									msgName:ZaMsg.MSG_zimbraEnforcePwdHistory,
 									txtBoxLabel:ZaMsg.LBL_zimbraEnforcePwdHistory, labelLocation:_LEFT_, 
 									textFieldCssClass:"admin_xform_number_input",
-									visibilityChecks:[],enableDisableChecks:[[ZaAccountXFormView.isAuthfromInternalSync, entry.name, ZaAccount.A_name]]
-								},
-								{ref:ZaAccount.A_zimbraPasswordBlockCommonEnabled, type:_SUPER_CHECKBOX_, 
-									resetToSuperLabel:ZaMsg.NAD_ResetToCOS, 
-									msgName:ZaMsg.NAD_RejectCommonPwd,
-									checkBoxLabel:ZaMsg.NAD_RejectCommonPwd, 
-									trueValue:"TRUE", falseValue:"FALSE",
 									visibilityChecks:[],enableDisableChecks:[[ZaAccountXFormView.isAuthfromInternalSync, entry.name, ZaAccount.A_name]]
 								}
 							]

--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaNewAccountXWizard.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaNewAccountXWizard.js
@@ -2129,7 +2129,7 @@ ZaNewAccountXWizard.myXFormModifier = function(xFormObject, entry) {
         if(ZAWizTopGrouper_XFormItem.isGroupVisible(entry,[ZaAccount.A_zimbraPasswordLocked,ZaAccount.A_zimbraMinPwdLength,
             ZaAccount.A_zimbraMaxPwdLength,ZaAccount.A_zimbraPasswordMinUpperCaseChars,ZaAccount.A_zimbraPasswordMinLowerCaseChars,
             ZaAccount.A_zimbraPasswordMinPunctuationChars,ZaAccount.A_zimbraPasswordMinNumericChars,ZaAccount.A_zimbraPasswordMinDigitsOrPuncs,
-            ZaAccount.A_zimbraMinPwdAge,ZaAccount.A_zimbraMaxPwdAge,ZaAccount.A_zimbraEnforcePwdHistory, ZaAccount.A_zimbraPasswordBlockCommonEnabled],[])) {
+            ZaAccount.A_zimbraMinPwdAge,ZaAccount.A_zimbraMaxPwdAge,ZaAccount.A_zimbraEnforcePwdHistory],[])) {
             advancedCaseItems.push({type:_ZAWIZ_TOP_GROUPER_,id:"account_password_settings",colSizes:["auto"],numCols:1,
                             label:ZaMsg.NAD_PasswordGrouper,
                             items: [
@@ -2227,13 +2227,6 @@ ZaNewAccountXWizard.myXFormModifier = function(xFormObject, entry) {
                                     msgName:ZaMsg.MSG_zimbraEnforcePwdHistory,
                                     txtBoxLabel:ZaMsg.LBL_zimbraEnforcePwdHistory, labelLocation:_LEFT_,
                                     textFieldCssClass:"admin_xform_number_input",
-                                    colSizes:["200px", "300px", "*"],
-                                    visibilityChecks:[],enableDisableChecks:[[ZaNewAccountXWizard.isAuthfromInternal, domainName,ZaAccount.A_name]]
-                                },
-                                {ref:ZaAccount.A_zimbraPasswordBlockCommonEnabled,
-                                    type:_SUPER_WIZ_CHECKBOX_, resetToSuperLabel:ZaMsg.NAD_ResetToCOS,
-                                    msgName:ZaMsg.NAD_RejectCommonPwd,checkBoxLabel:ZaMsg.NAD_RejectCommonPwd,
-                                    trueValue:"TRUE", falseValue:"FALSE",
                                     colSizes:["200px", "300px", "*"],
                                     visibilityChecks:[],enableDisableChecks:[[ZaNewAccountXWizard.isAuthfromInternal, domainName,ZaAccount.A_name]]
                                 }

--- a/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
+++ b/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
@@ -55,7 +55,6 @@ ZaCos.A_zimbraMinPwdAge = "zimbraPasswordMinAge";
 ZaCos.A_zimbraMaxPwdAge = "zimbraPasswordMaxAge";
 ZaCos.A_zimbraEnforcePwdHistory ="zimbraPasswordEnforceHistory";
 ZaCos.A_zimbraPasswordLocked = "zimbraPasswordLocked";
-ZaCos.A_zimbraPasswordBlockCommonEnabled = "zimbraPasswordBlockCommonEnabled";
 ZaCos.A_name = "cn";
 ZaCos.A_description = "description";
 ZaCos.A_zimbraAttachmentsBlocked = "zimbraAttachmentsBlocked";
@@ -647,7 +646,6 @@ ZaCos.myXModel = {
         {id:ZaCos.A_zimbraMaxPwdAge, type:_NUMBER_, ref:"attrs/"+ZaCos.A_zimbraMaxPwdAge, maxInclusive:2147483647, minInclusive:0},
         {id:ZaCos.A_zimbraEnforcePwdHistory, type:_NUMBER_, ref:"attrs/"+ZaCos.A_zimbraEnforcePwdHistory, maxInclusive:2147483647, minInclusive:0},
         {id:ZaCos.A_zimbraPasswordLocked, type:_ENUM_, choices:ZaModel.BOOLEAN_CHOICES, ref:"attrs/"+ZaCos.A_zimbraPasswordLocked},
-        {id:ZaCos.A_zimbraPasswordBlockCommonEnabled, type:_ENUM_, choices:ZaModel.BOOLEAN_CHOICES, ref:"attrs/"+ZaCos.A_zimbraPasswordBlockCommonEnabled},
         {id:ZaCos.A_name, type:_STRING_, ref:"attrs/"+ZaCos.A_name},
 //        {id:ZaCos.A_description, type:_STRING_, ref:"attrs/"+ZaCos.A_description},
         ZaItem.descriptionModelItem ,

--- a/WebRoot/js/zimbraAdmin/cos/view/ZaCosXFormView.js
+++ b/WebRoot/js/zimbraAdmin/cos/view/ZaCosXFormView.js
@@ -314,7 +314,6 @@ ZaCosXFormView.ADVANCED_TAB_ATTRS = [ZaCos.A_zimbraAttachmentsBlocked,
 	ZaCos.A_zimbraQuotaWarnInterval,
 	ZaCos.A_zimbraQuotaWarnMessage,
 	ZaCos.A_zimbraPasswordLocked,
-	ZaCos.A_zimbraPasswordBlockCommonEnabled,
 	ZaCos.A_zimbraMinPwdLength,
 	ZaCos.A_zimbraMaxPwdLength,
 	ZaCos.A_zimbraPasswordMinUpperCaseChars,
@@ -1655,13 +1654,7 @@ ZaCosXFormView.myXFormModifier = function(xFormObject, entry) {
             type:_TEXTFIELD_, msgName:ZaMsg.MSG_zimbraEnforcePwdHistory,
             label:ZaMsg.LBL_zimbraEnforcePwdHistory, labelLocation:_LEFT_, cssClass:"admin_xform_number_input",
             visibilityChecks:[],enableDisableChecks:[[ZaCosXFormView.isAllAuthfromInternal]]
-            },
-                    {ref:ZaCos.A_zimbraPasswordBlockCommonEnabled, type:_CHECKBOX_,
-            msgName:ZaMsg.NAD_RejectCommonPwd,
-            label:ZaMsg.NAD_RejectCommonPwd,
-            trueValue:"TRUE", falseValue:"FALSE",
-            visibilityChecks:[],enableDisableChecks:[[ZaCosXFormView.isAllAuthfromInternal]]
-            },
+            }
                 ]
             },
             {type:_ZA_TOP_GROUPER_, id:"cos_password_lockout_settings",

--- a/WebRoot/js/zimbraAdmin/cos/view/ZaNewCosXWizard.js
+++ b/WebRoot/js/zimbraAdmin/cos/view/ZaNewCosXWizard.js
@@ -416,7 +416,6 @@ ZaNewCosXWizard.ADVANCED_TAB_ATTRS = [ZaCos.A_zimbraAttachmentsBlocked,
     ZaCos.A_zimbraQuotaWarnInterval,
     ZaCos.A_zimbraQuotaWarnMessage,
     ZaCos.A_zimbraPasswordLocked,
-    ZaCos.A_zimbraPasswordBlockCommonEnabled,
     ZaCos.A_zimbraMinPwdLength,
     ZaCos.A_zimbraMaxPwdLength,
     ZaCos.A_zimbraPasswordMinUpperCaseChars,
@@ -1473,13 +1472,7 @@ ZaNewCosXWizard.myXFormModifier = function(xFormObject, entry) {
             type:_TEXTFIELD_, msgName:ZaMsg.MSG_zimbraEnforcePwdHistory,
             label:ZaMsg.LBL_zimbraEnforcePwdHistory, labelLocation:_LEFT_, cssClass:"admin_xform_number_input",
             visibilityChecks:[],enableDisableChecks:[[ZaNewCosXWizard.isAllAuthfromInternal]]
-            },
-                    {ref:ZaCos.A_zimbraPasswordBlockCommonEnabled, type:_WIZ_CHECKBOX_,
-            msgName:ZaMsg.NAD_RejectCommonPwd,
-            label:ZaMsg.NAD_RejectCommonPwd,
-            trueValue:"TRUE", falseValue:"FALSE",
-            visibilityChecks:[],enableDisableChecks:[[ZaNewCosXWizard.isAllAuthfromInternal]]
-            },
+            }
                 ]
             },
             {type:_ZAWIZ_TOP_GROUPER_, id:"cos_password_lockout_settings",

--- a/WebRoot/messages/ZaMsg.properties
+++ b/WebRoot/messages/ZaMsg.properties
@@ -1212,7 +1212,6 @@ NAD_Remove = Remove
 NAD_ForwardTo = Forward mail to
 NAD_COSName = COS Name
 NAD_PwdLocked = Prevent user from changing password
-NAD_RejectCommonPwd = Reject common passwords
 NAD_ResetToCOS = Reset to COS value
 NAD_OverrideCOS = Override COS
 NAD_ResetToGlobal = Reset to Global value

--- a/WebRoot/messages/ZaMsg_hr.properties
+++ b/WebRoot/messages/ZaMsg_hr.properties
@@ -1201,7 +1201,6 @@ NAD_Remove = Remove
 NAD_ForwardTo = Forward mail to
 NAD_COSName = COS Name
 NAD_PwdLocked = Prevent user from changing password
-NAD_RejectCommonPwd = Reject common passwords
 NAD_ResetToCOS = Reset to COS value
 NAD_OverrideCOS = Override COS
 NAD_ResetToGlobal = Reset to Global value


### PR DESCRIPTION
Bugs(reported for version 9.0.0):
1. Home > Configure > Class of Service > default > Advanced > under "Password" > there is an option "Reject common passwords" (zimbraPasswordBlockCommonEnabled) > if I check it and save it gets unchecked.
2. Home > Manage Accounts > select an account > Advanced > under "Password" > there is an option "Reject common passwords" (zimbraPasswordBlockCommonEnabled) > if I check it and save it gives error "Server error encountered".

Changes:

- Revert all changes made under #70.
- Revert a translation change made under #75.
