### PR TITLE
ZCS-13220: Add option in admin console to hide aliases in GAL for the user

### DIFF
--- a/WebRoot/js/zimbraAdmin/accounts/model/ZaAccount.js
+++ b/WebRoot/js/zimbraAdmin/accounts/model/ZaAccount.js
@@ -276,6 +276,7 @@ ZaAccount.A_zimbraFeatureSkinChangeEnabled = "zimbraFeatureSkinChangeEnabled";
 ZaAccount.A_zimbraFeatureOutOfOfficeReplyEnabled = "zimbraFeatureOutOfOfficeReplyEnabled";
 ZaAccount.A_zimbraFeatureNewMailNotificationEnabled = "zimbraFeatureNewMailNotificationEnabled";
 ZaAccount.A_zimbraHideInGal = "zimbraHideInGal";
+ZaAccount.A_zimbraHideAliasesInGal = "zimbraHideAliasesInGal";
 ZaAccount.A_zimbraMailCanonicalAddress = "zimbraMailCanonicalAddress";
 ZaAccount.A_zimbraMailCatchAllAddress = "zimbraMailCatchAllAddress" ;
 ZaAccount.A_zimbraFeatureOptionsEnabled = "zimbraFeatureOptionsEnabled";
@@ -2156,6 +2157,7 @@ ZaAccount.myXModel = {
         {id:ZaAccount.A2_calFwdAddr_selection_cache, type:_LIST_},
         {id:ZaAccount.A2_fp_selection_cache, type:_LIST_},
         {id:ZaAccount.A_zimbraHideInGal, type:_ENUM_, ref:"attrs/"+ZaAccount.A_zimbraHideInGal, choices:ZaModel.BOOLEAN_CHOICES},
+        {id:ZaAccount.A_zimbraHideAliasesInGal, type:_COS_ENUM_, ref:"attrs/"+ZaAccount.A_zimbraHideAliasesInGal, choices:ZaModel.BOOLEAN_CHOICES},
 
         {id:ZaAccount.A_zimbraMailTransport, type:_STRING_, ref:"attrs/"+ZaAccount.A_zimbraMailTransport},
 

--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaAccountXFormView.js
@@ -1074,7 +1074,8 @@ ZaAccountXFormView.ACCOUNT_NAME_GROUP_ATTRS = [ZaAccount.A_name,
         ZaAccount.A_initials,
         ZaAccount.A_lastName,
         ZaAccount.A_displayname,
-    ZaAccount.A_zimbraHideInGal
+        ZaAccount.A_zimbraHideInGal,
+        ZaAccount.A_zimbraHideAliasesInGal
 ];
 
 ZaAccountXFormView.MEMBEROF_TAB_ATTRS = [];
@@ -1400,6 +1401,10 @@ ZaAccountXFormView.getAccountNameInfoItem = function(){
                               msgName:ZaMsg.LBL_zimbraHideInGal,
                               label:ZaMsg.LBL_zimbraHideInGal, trueValue:"TRUE", falseValue:"FALSE"
                 },
+        ZaAccountXFormView.accountNameInfoPool[ZaAccount.A_zimbraHideAliasesInGal]={ref:ZaAccount.A_zimbraHideAliasesInGal, type:_CHECKBOX_,
+                    msgName:ZaMsg.LBL_zimbraHideAliasesInGal,
+                    label:ZaMsg.LBL_zimbraHideAliasesInGal, trueValue:"TRUE", falseValue:"FALSE"
+                },
         ZaAccountXFormView.accountNameInfoPool[ZaAccount.A_zimbraPhoneticFirstName] = {
                     ref:ZaAccount.A_zimbraPhoneticFirstName, type:_TEXTFIELD_,
                     msgName:ZaMsg.NAD_zimbraPhoneticFirstName,label:ZaMsg.NAD_zimbraPhoneticFirstName,
@@ -1416,10 +1421,10 @@ ZaAccountXFormView.getAccountNameInfoItem = function(){
     var accountNameFormItems = new Array();
         var accountNameItemsOrders = new Array();
         if(ZaZimbraAdmin.isLanguage("ja")){
-        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_zimbraPhoneticLastName, ZaAccount.A_lastName, ZaAccount.A_initials, ZaAccount.A_zimbraPhoneticFirstName, ZaAccount.A_firstName, "ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal];
+        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_zimbraPhoneticLastName, ZaAccount.A_lastName, ZaAccount.A_initials, ZaAccount.A_zimbraPhoneticFirstName, ZaAccount.A_firstName, "ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal, ZaAccount.A_zimbraHideAliasesInGal];
         }
         else{
-        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_firstName, ZaAccount.A_initials, ZaAccount.A_lastName,"ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal];
+        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_firstName, ZaAccount.A_initials, ZaAccount.A_lastName,"ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal, ZaAccount.A_zimbraHideAliasesInGal];
         }
 
         for(var i = 0; i < accountNameItemsOrders.length; i++){

--- a/WebRoot/js/zimbraAdmin/accounts/view/ZaNewAccountXWizard.js
+++ b/WebRoot/js/zimbraAdmin/accounts/view/ZaNewAccountXWizard.js
@@ -539,6 +539,10 @@ ZaNewAccountXWizard.getAccountNameInfoItem = function(){
                               msgName:ZaMsg.LBL_zimbraHideInGal, subLabel:"", labelLocation:_RIGHT_,align:_RIGHT_,
                               label:ZaMsg.LBL_zimbraHideInGal, trueValue:"TRUE", falseValue:"FALSE"
                 },
+        ZaNewAccountXWizard.accountNameInfoPool[ZaAccount.A_zimbraHideAliasesInGal]={ref:ZaAccount.A_zimbraHideAliasesInGal, type:_WIZ_CHECKBOX_,
+                    msgName:ZaMsg.LBL_zimbraHideAliasesInGal, subLabel:"", labelLocation:_RIGHT_,align:_RIGHT_,
+                    label:ZaMsg.LBL_zimbraHideAliasesInGal, trueValue:"TRUE", falseValue:"FALSE"
+                },
         ZaNewAccountXWizard.accountNameInfoPool[ZaAccount.A_zimbraPhoneticFirstName] = {
                     ref:ZaAccount.A_zimbraPhoneticFirstName, type:_TEXTFIELD_,
                     msgName:ZaMsg.NAD_zimbraPhoneticFirstName,label:ZaMsg.NAD_zimbraPhoneticFirstName,
@@ -555,10 +559,10 @@ ZaNewAccountXWizard.getAccountNameInfoItem = function(){
     var accountNameFormItems = new Array();
         var accountNameItemsOrders = new Array();
         if(ZaZimbraAdmin.isLanguage("ja")){
-        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_zimbraPhoneticLastName, ZaAccount.A_lastName, ZaAccount.A_initials, ZaAccount.A_zimbraPhoneticFirstName, ZaAccount.A_firstName, "ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal];
+        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_zimbraPhoneticLastName, ZaAccount.A_lastName, ZaAccount.A_initials, ZaAccount.A_zimbraPhoneticFirstName, ZaAccount.A_firstName, "ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal, ZaAccount.A_zimbraHideAliasesInGal];
         }
         else{
-        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_firstName, ZaAccount.A_initials, ZaAccount.A_lastName,"ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal];
+        accountNameItemsOrders = [ZaAccount.A_name, ZaAccount.A_firstName, ZaAccount.A_initials, ZaAccount.A_lastName,"ZaAccountDisplayInfoGroup", ZaAccount.A_zimbraHideInGal, ZaAccount.A_zimbraHideAliasesInGal];
         }
 
         for(var i = 0; i < accountNameItemsOrders.length; i++){


### PR DESCRIPTION
ZCS-13220: Add option in admin console to hide aliases in GAL for the user.

Problem: In Admin Console, provide the **Hide aliases in GAL** option on the Account level.

Solution: Added **Hide aliases in GAL** Checkbox in Account level.