### PR TITLE
ZCS-14111: added xform to support multiple checkboxes in a single setting. Added logic to add attributes to CreateDomainRequest.

### DIFF
--- a/WebRoot/admin_skins/serenity/skin.css
+++ b/WebRoot/admin_skins/serenity/skin.css
@@ -623,6 +623,10 @@ TD.gridGroupBodyLabel {
 .grid_table TD TD {
 	border:0px;
 }
+.grid_table .xform_multiple_checkbox {
+	border-right:1px solid #E4E4E4;
+}
+
 .grid_composite_table,
 .grid_xform_table {
 	border-spacing:0;

--- a/WebRoot/js/zimbraAdmin/common/Super_XFormItems.js
+++ b/WebRoot/js/zimbraAdmin/common/Super_XFormItems.js
@@ -673,6 +673,192 @@ Super_Checkbox_XFormItem.prototype.initializeItems = function() {
 Super_Checkbox_XFormItem.prototype.items = []; 
 
 
+/**
+*	_SUPER_MULTIPLE_CHECKBOX_ form item type
+**/
+SuperSelect_MultipleCheckbox_XFormItem = function () {}
+XFormItemFactory.createItemType("_SUPER_MULTIPLE_CHECKBOX_", "super_multiple_checkbox", SuperSelect_MultipleCheckbox_XFormItem, Super_XFormItem);
+SuperSelect_MultipleCheckbox_XFormItem.prototype.numCols = 3;
+SuperSelect_MultipleCheckbox_XFormItem.prototype.colSpan = 3;
+SuperSelect_MultipleCheckbox_XFormItem.prototype.colSizes = ["275px","225px", "*"];
+SuperSelect_MultipleCheckbox_XFormItem.prototype.nowrap = false;
+SuperSelect_MultipleCheckbox_XFormItem.prototype.labelWrap = true;
+SuperSelect_MultipleCheckbox_XFormItem.prototype.items = [];
+SuperSelect_MultipleCheckbox_XFormItem.prototype.labelCssStyle = "border-right: 1px solid black;";
+SuperSelect_MultipleCheckbox_XFormItem.prototype.labelCssClass = "gridGroupBodyLabel";
+SuperSelect_MultipleCheckbox_XFormItem.prototype.tableCssClass = "grid_composite_table";
+
+/**
+*	_SUPER_WIZ_MULTIPLE_CHECKBOX_ form item type
+**/
+SuperWiz_MultipleCheck_XFormItem = function () {}
+XFormItemFactory.createItemType("_SUPER_WIZ_MULTIPLE_CHECKBOX_", "super_wiz_multiple_checkbox", SuperWiz_MultipleCheck_XFormItem, SuperSelect_MultipleCheckbox_XFormItem);
+
+SuperWiz_MultipleCheck_XFormItem.prototype.colSizes = ["200px","300px","150px"];
+SuperWiz_MultipleCheck_XFormItem.prototype.visibilityChecks = [ZaItem.hasWritePermission];
+SuperWiz_MultipleCheck_XFormItem.prototype.enableDisableChecks = [ZaItem.hasWritePermission];
+SuperWiz_MultipleCheck_XFormItem.prototype.labelCssStyle = "";
+SuperWiz_MultipleCheck_XFormItem.prototype.labelCssClass = "";
+SuperWiz_MultipleCheck_XFormItem.prototype.checkBoxLabelLocation = _RIGHT_;
+SuperWiz_MultipleCheck_XFormItem.prototype.checkboxSubLabel = "";
+SuperWiz_MultipleCheck_XFormItem.prototype.checkboxAlign = _RIGHT_;
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.initializeItems = function() {
+	var choices = this.getInheritedProperty("choices");
+	var label = this.getInheritedProperty("groupLabel");
+
+	var selectChck = {
+		type: _OSELECT_CHECK_,
+		choices: choices,
+		ref: ".",
+		width: "225px",
+		onChange: function(value, event, form) {
+			if (this.getParentItem() && this.getParentItem().getParentItem() && this.getParentItem().getParentItem().getOnChangeMethod()) {
+				return this.getParentItem().getParentItem().getOnChangeMethod().call(this, value, event, form);
+			} else {
+				return this.setInstanceValue(value);
+			}
+		},
+		forceUpdate: true,
+		updateElement: function(value) {
+			Super_XFormItem.updateCss.call(this, 9);
+			if (!(value instanceof Array)) {
+				value = [value];
+			}
+			OSelect_XFormItem.prototype.updateElement.call(this, value);
+		},
+		cssStyle: "border:none;"
+	};
+
+	var selectChckGrp = {
+		type: _GROUP_,
+		ref: ".",
+		items: [selectChck]
+	};
+
+	selectChckGrp.label = label;
+	selectChckGrp.labelCssClass = this.getInheritedProperty("labelCssClass");
+	selectChckGrp.labelCssStyle = this.getInheritedProperty("labelCssStyle");
+	selectChckGrp.cssClass = "";
+
+	var anchorHlpr = {
+		type: _SUPER_ANCHOR_HELPER_, ref:".",
+		visibilityChecks: [Super_XFormItem.checkIfOverWriten],
+		visibilityChangeEventSources: [this.getRefPath()],
+		onChange: Composite_XFormItem.onFieldChange,
+		cssStyle: "width:150px"
+	};
+
+	this.items = [selectChckGrp, anchorHlpr];
+
+	Composite_XFormItem.prototype.initializeItems.call(this);
+
+	// replace class name and functions defined in OSelect_Check_XFormItem
+	this.containerCssClass = "xform_container";
+	this.items[0].items[0].cssClass = this.containerCssClass;
+	this.items[0].items[0].getChoiceSelectedCssClass = this.__getChoiceSelectedCssClass;
+	this.items[0].items[0].getChoiceCssClass = this.__getChoiceCssClass;
+	this.items[0].items[0].getChoiceHTML = this.__getChoiceHTML;
+	this.items[0].items[0].setElementEnabled = this.__setElementEnabled;
+
+	this.items[0].items[0].onChoiceOverOriginal = this.items[0].items[0].onChoiceOver;
+	this.items[0].items[0].onChoiceOver = this.__onChoiceOver;
+
+	this.items[0].items[0].onChoiceOutOriginal = this.items[0].items[0].onChoiceOut;
+	this.items[0].items[0].onChoiceOut = this.__onChoiceOut;
+
+	this.items[0].items[0].onChoiceClickOriginal = this.items[0].items[0].onChoiceClick;
+	this.items[0].items[0].onChoiceClick = this.__onChoiceClick;
+
+	this.items[0].items[0].onChoiceDoubleClickOriginal = this.items[0].items[0].onChoiceDoubleClick;
+	this.items[0].items[0].onChoiceDoubleClick = this.__onChoiceDoubleClick;
+};
+
+// functions to replace the ones defined in OSelect_Check_XFormItem
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__getChoiceSelectedCssClass =
+function() {
+	return this.containerCssClass;
+};
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__getChoiceCssClass =
+function() {
+	return this.containerCssClass;
+};
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__getChoiceHTML =
+function(itemNum, value, label, cssClass) {
+	var ref = this.getFormGlobalRef() + ".getItemById('"+ this.getId()+ "')";
+	var id = this.getId();
+	return AjxBuffer.concat(
+		"<tr><td class=", cssClass,
+			" onmouseover=\"" + ref + ".onChoiceOver(" + itemNum + ", event||window.event)\"",
+			" onmouseout=\"" + ref +  ".onChoiceOut(" + itemNum + ", event||window.event)\"",
+			" onclick=\"" + ref + ".onChoiceClick(" + itemNum + ", event||window.event)\"",
+			" ondblclick=\"" + ref + ".onChoiceDoubleClick(" + itemNum + ", event||window.event)\"",
+		">",
+		"<table cellspacing=0 cellpadding=0><tr><td><input type=checkbox id='",id,"_choiceitem_",itemNum,"'></td><td>",
+		        "<font id=", id, "_label_", itemNum, ">", AjxStringUtil.htmlEncode(label), "</font>",
+		"</td></tr></table></td></tr>"
+	);
+};
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__setElementEnabled =
+function(enabled) {
+	var choices = this.getNormalizedChoices();
+	if (!choices) {
+		return;
+	}
+	var values = choices.values;
+	if (!values) {
+		return;
+	}
+	var cnt = values.length;
+	for (var i = 0; i < cnt; i++) {
+		var checkbox = this.getElement(this.getId() + "_choiceitem_" + i);
+		var label = this.getElement(this.getId() + "_label_" + i);
+		if (checkbox) {
+			if (enabled) {
+				checkbox.className = this.getChoiceCssClass();
+				checkbox.disabled = false;
+				label.style.color ="";
+			} else {
+				checkbox.className = this.getChoiceCssClass() + "_disabled";
+				checkbox.disabled = true;
+				label.style.color ="#808080";
+			}
+		}
+	}
+};
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__onChoiceOver =
+function(itemNum) {
+	if (this.getIsEnabled()) {
+		this.onChoiceOverOriginal(itemNum);
+	}
+};
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__onChoiceOut =
+function(itemNum) {
+	if (this.getIsEnabled()) {
+		this.onChoiceOutOriginal(itemNum);
+	}
+};
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__onChoiceClick =
+function(itemNum, event) {
+	if (this.getIsEnabled()) {
+		this.onChoiceClickOriginal(itemNum, event);
+	}
+};
+
+SuperSelect_MultipleCheckbox_XFormItem.prototype.__onChoiceDoubleClick =
+function(itemNum, event) {
+	// address double click as a single click
+	if (this.getIsEnabled()) {
+		this.onChoiceClickOriginal(itemNum, event);
+	}
+};
+
 
 /**
 *	SUPER__HOSTPORT_ form item type

--- a/WebRoot/js/zimbraAdmin/common/ZaSelectMultipleCheckboxXFormItem.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaSelectMultipleCheckboxXFormItem.js
@@ -1,0 +1,195 @@
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Zimbra Collaboration Suite Web Client
+ * Copyright (C) 2023 Synacor, Inc.
+ *
+ * The contents of this file are subject to the Common Public Attribution License Version 1.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at: https://www.zimbra.com/license
+ * The License is based on the Mozilla Public License Version 1.1 but Sections 14 and 15
+ * have been added to cover use of software over a computer network and provide for limited attribution
+ * for the Original Developer. In addition, Exhibit A has been modified to be consistent with Exhibit B.
+ *
+ * Software distributed under the License is distributed on an "AS IS" basis,
+ * WITHOUT WARRANTY OF ANY KIND, either express or implied.
+ * See the License for the specific language governing rights and limitations under the License.
+ * The Original Code is Zimbra Open Source Web Client.
+ * The Initial Developer of the Original Code is Zimbra, Inc.  All rights to the Original Code were
+ * transferred by Zimbra, Inc. to Synacor, Inc. on September 14, 2015.
+ *
+ * All portions of the code are Copyright (C) 2023 Synacor, Inc. All Rights Reserved.
+ * ***** END LICENSE BLOCK *****
+ */
+/**
+*	_ZASELECT_MULTIPLE_CHECKBOX_ form item type
+**/
+ZaSelectMultipleCheckbox_XFormItem = function () {}
+XFormItemFactory.createItemType("_ZASELECT_MULTIPLE_CHECKBOX_", "zaselect_multiple_checkbox", ZaSelectMultipleCheckbox_XFormItem, Composite_XFormItem);
+ZaSelectMultipleCheckbox_XFormItem.prototype.numCols=3;
+ZaSelectMultipleCheckbox_XFormItem.prototype.colSpan=3;
+ZaSelectMultipleCheckbox_XFormItem.prototype.colSizes=["275px","225px", "*"];
+ZaSelectMultipleCheckbox_XFormItem.prototype.nowrap = false;
+ZaSelectMultipleCheckbox_XFormItem.prototype.labelWrap = true;
+ZaSelectMultipleCheckbox_XFormItem.prototype.items = [];
+ZaSelectMultipleCheckbox_XFormItem.prototype.labelWidth = "275px";
+ZaSelectMultipleCheckbox_XFormItem.prototype.labelCssStyle = "";
+ZaSelectMultipleCheckbox_XFormItem.prototype.labelCssClass = "gridGroupBodyLabel xform_multiple_checkbox";
+ZaSelectMultipleCheckbox_XFormItem.prototype.tableCssClass = "grid_composite_table";
+ZaSelectMultipleCheckbox_XFormItem.prototype.visibilityChecks = [ZaItem.hasReadPermission];
+ZaSelectMultipleCheckbox_XFormItem.prototype.enableDisableChecks = [ZaItem.hasWritePermission];
+
+ZaSelectWiz_MultipleCheckbox_XFormItem = function () {}
+XFormItemFactory.createItemType("_ZASELECT_WIZ_MULTIPLE_CHECKBOX_", "zaselect_wiz_multiple_checkbox", ZaSelectWiz_MultipleCheckbox_XFormItem, ZaSelectMultipleCheckbox_XFormItem);
+ZaSelectWiz_MultipleCheckbox_XFormItem.prototype.colSizes = ["200px","300px","150px"];
+ZaSelectWiz_MultipleCheckbox_XFormItem.prototype.labelCssStyle = "";
+ZaSelectWiz_MultipleCheckbox_XFormItem.prototype.labelCssClass = "";
+ZaSelectWiz_MultipleCheckbox_XFormItem.prototype.checkBoxLabelLocation = _RIGHT_;
+ZaSelectWiz_MultipleCheckbox_XFormItem.prototype.checkboxSubLabel = "";
+ZaSelectWiz_MultipleCheckbox_XFormItem.prototype.checkboxAlign = _RIGHT_;
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.initializeItems = function() {
+	var choices = this.getInheritedProperty("choices");
+	var label = this.getInheritedProperty("groupLabel");
+
+	var selectChck = {
+		type: _OSELECT_CHECK_,
+		choices: choices,
+		ref: ".",
+		width: "275px",
+		onChange: function(value, event, form) {
+			if (this.getParentItem() && this.getParentItem().getParentItem() && this.getParentItem().getParentItem().getOnChangeMethod()) {
+				return this.getParentItem().getParentItem().getOnChangeMethod().call(this, value, event, form);
+			} else {
+				return this.setInstanceValue(value);
+			}
+		},
+		forceUpdate: true,
+		updateElement: function(value) {
+			if (!(value instanceof Array)) {
+				value = [value];
+			}
+			OSelect_XFormItem.prototype.updateElement.call(this, value);
+		},
+		cssStyle: "border:none;"
+	};
+
+	var selectChckGrp = {
+		type: _GROUP_,
+		ref: ".",
+		items: [selectChck]
+	};
+
+	selectChckGrp.label = label;
+	selectChckGrp.labelCssClass = this.getInheritedProperty("labelCssClass");
+	selectChckGrp.labelCssStyle = this.getInheritedProperty("labelCssStyle");
+	selectChckGrp.cssClass = "";
+
+	this.items = [selectChckGrp];
+
+	Composite_XFormItem.prototype.initializeItems.call(this);
+
+	// replace class name and functions defined in OSelect_Check_XFormItem
+	this.containerCssClass = "xform_container";
+	this.items[0].items[0].cssClass = this.containerCssClass;
+	this.items[0].items[0].getChoiceSelectedCssClass = this.__getChoiceSelectedCssClass;
+	this.items[0].items[0].getChoiceCssClass = this.__getChoiceCssClass;
+	this.items[0].items[0].getChoiceHTML = this.__getChoiceHTML;
+	this.items[0].items[0].setElementEnabled = this.__setElementEnabled;
+
+	this.items[0].items[0].onChoiceOverOriginal = this.items[0].items[0].onChoiceOver;
+	this.items[0].items[0].onChoiceOver = this.__onChoiceOver;
+
+	this.items[0].items[0].onChoiceOutOriginal = this.items[0].items[0].onChoiceOut;
+	this.items[0].items[0].onChoiceOut = this.__onChoiceOut;
+
+	this.items[0].items[0].onChoiceClickOriginal = this.items[0].items[0].onChoiceClick;
+	this.items[0].items[0].onChoiceClick = this.__onChoiceClick;
+
+	this.items[0].items[0].onChoiceDoubleClickOriginal = this.items[0].items[0].onChoiceDoubleClick;
+	this.items[0].items[0].onChoiceDoubleClick = this.__onChoiceDoubleClick;
+};
+
+// functions to replace the ones defined in OSelect_Check_XFormItem
+ZaSelectMultipleCheckbox_XFormItem.prototype.__getChoiceSelectedCssClass =
+function() {
+	return this.containerCssClass;
+};
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.__getChoiceCssClass =
+function() {
+	return this.containerCssClass;
+};
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.__getChoiceHTML =
+function(itemNum, value, label, cssClass) {
+	var ref = this.getFormGlobalRef() + ".getItemById('"+ this.getId()+ "')";
+	var id = this.getId();
+	return AjxBuffer.concat(
+		"<tr><td class=", cssClass,
+			" onmouseover=\"" + ref + ".onChoiceOver(" + itemNum + ", event||window.event)\"",
+			" onmouseout=\"" + ref +  ".onChoiceOut(" + itemNum + ", event||window.event)\"",
+			" onclick=\"" + ref + ".onChoiceClick(" + itemNum + ", event||window.event)\"",
+			" ondblclick=\"" + ref + ".onChoiceDoubleClick(" + itemNum + ", event||window.event)\"",
+		">",
+		"<table cellspacing=0 cellpadding=0><tr><td><input type=checkbox id='",id,"_choiceitem_",itemNum,"'></td><td>",
+		        "<font id=", id, "_label_", itemNum, ">", AjxStringUtil.htmlEncode(label), "</font>",
+		"</td></tr></table></td></tr>"
+	);
+};
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.__setElementEnabled =
+function(enabled) {
+	var choices = this.getNormalizedChoices();
+	if (!choices) {
+		return;
+	}
+	var values = choices.values;
+	if (!values) {
+		return;
+	}
+	var cnt = values.length;
+	for (var i = 0; i < cnt; i++) {
+		var chkbx = this.getElement(this.getId() + "_choiceitem_" + i);
+		var label = this.getElement(this.getId() + "_label_" + i);
+		if (chkbx) {
+			if (enabled) {
+				chkbx.className = this.getChoiceCssClass();
+				chkbx.disabled = false;
+				label.style.color ="";
+			} else {
+				chkbx.className = this.getChoiceCssClass() + "_disabled";
+				chkbx.disabled = true;
+				label.style.color ="#808080";
+			}
+		}
+	}
+};
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.__onChoiceOver =
+function(itemNum) {
+	if (this.getIsEnabled()) {
+		this.onChoiceOverOriginal(itemNum);
+	}
+};
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.__onChoiceOut =
+function(itemNum) {
+	if (this.getIsEnabled()) {
+		this.onChoiceOutOriginal(itemNum);
+	}
+};
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.__onChoiceClick =
+function(itemNum, event) {
+	if (this.getIsEnabled()) {
+		this.onChoiceClickOriginal(itemNum, event);
+	}
+};
+
+ZaSelectMultipleCheckbox_XFormItem.prototype.__onChoiceDoubleClick =
+function(itemNum, event) {
+	// address double click as a single click
+	if (this.getIsEnabled()) {
+		this.onChoiceClickOriginal(itemNum, event);
+	}
+};

--- a/WebRoot/js/zimbraAdmin/domains/model/ZaDomain.js
+++ b/WebRoot/js/zimbraAdmin/domains/model/ZaDomain.js
@@ -514,6 +514,10 @@ ZaDomain._getAllCallback = function(callback, response) {
 	return list;
 };
 
+
+// array of function(s) to set additional attribute(s) to CreateDomainRequest
+ZaDomain.functionsToAddAttributesToCreateDomain = new Array();
+
 /**
 * Creates a new ZaDomain. This method makes SOAP request (CreateDomainRequest) to create a new domain record in LDAP. 
 * @param attrs
@@ -909,6 +913,14 @@ function(tmpObj, newDomain) {
         attr = soapDoc.set("a", tmpObj.attrs[ZaDomain.A_zimbraDomainAggregateQuotaPolicy]);
         attr.setAttribute("n", ZaDomain.A_zimbraDomainAggregateQuotaPolicy);
     }
+
+    // set additional attribute(s) via admin zimlet
+    for (var i = 0; i < ZaDomain.functionsToAddAttributesToCreateDomain.length; i++) {
+        if (ZaDomain.functionsToAddAttributesToCreateDomain[i] && typeof ZaDomain.functionsToAddAttributesToCreateDomain[i] === "function") {
+            ZaDomain.functionsToAddAttributesToCreateDomain[i].call(window, tmpObj, soapDoc);
+        }
+    }
+
 	//var command = new ZmCsfeCommand();
 	var params = new Object();
 	params.soapDoc = soapDoc;	

--- a/WebRoot/js/zimbraAdmin/domains/view/ZaDomainXFormView.js
+++ b/WebRoot/js/zimbraAdmin/domains/view/ZaDomainXFormView.js
@@ -1433,7 +1433,7 @@ ZaDomainXFormView.myXFormModifier = function(xFormObject,entry) {
                     ]
                 },
 
-                {type:_ZA_TOP_GROUPER_, label:ZaMsg.Domain_QUOTA_Configuration,
+                {type:_ZA_TOP_GROUPER_, label:ZaMsg.Domain_QUOTA_Configuration, id:"domain_quota",
                     visibilityChecks:[[ZATopGrouper_XFormItem.isGroupVisible, [
                             ZaDomain.A_zimbraMailDomainQuota,
                             ZaDomain.A_zimbraDomainAggregateQuota,
@@ -1466,6 +1466,12 @@ ZaDomainXFormView.myXFormModifier = function(xFormObject,entry) {
                 },
                 {type:_ZA_TOP_GROUPER_, id:"domain_admin_sieve",
                     label:ZaMsg.NAD_AdminSieveGrouper,
+                    visibilityChecks:[[ZATopGrouper_XFormItem.isGroupVisible, [
+                            ZaDomain.A_zimbraSieveRejectMailEnabled,
+                            ZaDomain.A_zimbraSieveEditHeaderEnabled,
+                            ZaDomain.A_zimbraAdminSieveScriptBefore,
+                            ZaDomain.A_zimbraAdminSieveScriptAfter
+                        ]]],
                     items: [
                         { type: _DWT_ALERT_,
                           containerCssStyle: "padding-bottom:0;",

--- a/WebRoot/js/zimbraAdmin/domains/view/ZaNewDomainXWizard.js
+++ b/WebRoot/js/zimbraAdmin/domains/view/ZaNewDomainXWizard.js
@@ -1658,7 +1658,7 @@ ZaNewDomainXWizard.myXFormModifier = function(xFormObject, entry) {
 						}
 					]
 				},
-				{type:_CASE_, caseKey:ZaNewDomainXWizard.ADVANCED_STEP, numCols:1, 
+				{type:_CASE_, caseKey:ZaNewDomainXWizard.ADVANCED_STEP, numCols:1, id:"domain_form_advanced_tab",
 					items: [
 						{ type:_ZAWIZ_TOP_GROUPER_, label:ZaMsg.Domain_BC_ShareConf,
                             items :[
@@ -1685,7 +1685,7 @@ ZaNewDomainXWizard.myXFormModifier = function(xFormObject, entry) {
                                     }
 						   ]
                         },
-                        {type:_ZAWIZ_TOP_GROUPER_, label:ZaMsg.Domain_QUOTA_Configuration,
+                        {type:_ZAWIZ_TOP_GROUPER_, label:ZaMsg.Domain_QUOTA_Configuration, id:"domain_form_domain_quota_settings",
                             colSizes:["200px","*"],
                             items:[
                                 {ref:ZaDomain.A_zimbraMailDomainQuota, type:_TEXTFIELD_,

--- a/WebRoot/js/zimbraAdmin/globalconfig/view/GlobalConfigXFormView.js
+++ b/WebRoot/js/zimbraAdmin/globalconfig/view/GlobalConfigXFormView.js
@@ -1423,6 +1423,7 @@ GlobalConfigXFormView.myXFormModifier = function(xFormObject, entry) {
                 } ]
             }, {
                 type : _ZA_TOP_GROUPER_,
+                id: "global_mail_address_validation_regex_setting",
                 label : ZaMsg.Domain_AD_EmailValidate,
                 visibilityChecks : [ [ ZaItem.hasReadPermission, ZaGlobalConfig.A_zimbraMailAddressValidationRegex ] ],
                 visibilityChangeEventSources : [ ZaGlobalConfig.A_zimbraMailAddressValidationRegex ],

--- a/WebRoot/js/zimbraAdmin/package/Admin.js
+++ b/WebRoot/js/zimbraAdmin/package/Admin.js
@@ -66,6 +66,7 @@ AjxPackage.require("zimbraAdmin.common.LDAPURL_XFormItem");
 AjxPackage.require("zimbraAdmin.common.HostPort_XFormItem");
 AjxPackage.require("zimbraAdmin.common.MailQuota_XModelItem");
 AjxPackage.require("zimbraAdmin.common.ZaSelectRadioXFormItem");
+AjxPackage.require("zimbraAdmin.common.ZaSelectMultipleCheckboxXFormItem");
 AjxPackage.require("zimbraAdmin.common.ZaZimletSelectXFormItem");
 AjxPackage.require("zimbraAdmin.common.ZaCheckBoxListXFormItem");
 AjxPackage.require("zimbraAdmin.common.Signature_XFormItem");


### PR DESCRIPTION
**Issues:**
1. some attributes have been added for Two-factor authentication on https://github.com/Zimbra/zm-mailbox/pull/1519 .
   `zimbraTwoFactorAuthMethodAllowed` and `zimbraTwoFactorAuthMethodEnabled` can have multiple values; `app` and `email`. Each method of the settings need to be enabled/disabled on admin console.
   However, there is no xform item to support multiple checkboxes in a single setting (attribute). 

2. In CreateDomainRequest, only limited attributes can be set. No other attributes cannot be set in the soap request.

**Changes:**
For 1,
* add the following xform types
   * `_SUPER_MULTIPLE_CHECKBOX_`: `accountInherited` (`Reset to COS value` button) is supported. Used in Edit account page.
   * `_SUPER_WIZ_MULTIPLE_CHECKBOX_`: same as the above. Used in New account page.
   * `_ZASELECT_MULTIPLE_CHECKBOX_`: `accountInherited` (`Reset to COS value` button) is not supported.
* the xform items are based on `_OSELECT_CHECK_` type. Most of functions defined in `_OSELECT_CHECK_` can be reused, but some functions cannot. Then functions are defined and replaced after an item is initialized.
* Reference: definition of `_OSELECT_CHECK_`
   https://github.com/Zimbra/zm-admin-ajax/blob/develop/WebRoot/js/ajax/dwt/xforms/OSelect_XFormItem.js#L1044

For 2,
* add mechanism in ZaDomain.js so that an attribute can be added via an admin zimlet

Additional changes:
* add visibilityChecks and id to existing settings