### PR TITLE
ZCS-14190: User should get proper error message for creating external storage and creating buckets and volumes from UI when hsm is disabled.

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/ZaTree.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaTree.js
@@ -525,16 +525,12 @@ function(item, ev) {
         this._selectedItems.add(item);
 
         if (item._setSelected(true)) {
-            if (item._text === ZaMsg.NAD_Tab_HSM) {
-                if (ZaHSM && ZaHSM.checkstoragefeaturenabled()) {
-                    this._updateHistory(item, true, isShowInHistory);
-                    this._notifyListeners(DwtEvent.SELECTION, [item], DwtTree.ITEM_SELECTED, ev, this._selEv);
-                } else {
-                    ZaApp.getInstance().getCurrentController().popupErrorDialog(ZaMsg.ERROR_Feature_Not_Licensed);
-                }
-            } else {
+            if ((item._text === ZaMsg.NAD_Tab_HSM && typeof ZaHSM !== 'undefined' && ZaHSM.checkstoragefeaturenabled()) ||
+                item._text !== ZaMsg.NAD_Tab_HSM) {
                 this._updateHistory(item, true, isShowInHistory);
                 this._notifyListeners(DwtEvent.SELECTION, [item], DwtTree.ITEM_SELECTED, ev, this._selEv);
+            } else {
+                ZaApp.getInstance().getCurrentController().popupErrorDialog(ZaMsg.ERROR_FEATURE_NOT_LICENSED);
             }
         }
 	} else {

--- a/WebRoot/js/zimbraAdmin/common/ZaTree.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaTree.js
@@ -530,7 +530,7 @@ function(item, ev) {
                     this._updateHistory(item, true, isShowInHistory);
                     this._notifyListeners(DwtEvent.SELECTION, [item], DwtTree.ITEM_SELECTED, ev, this._selEv);
                 } else {
-                    ZaApp.getInstance().getCurrentController().popupErrorDialog(ZaMsg.ERROR_Feature_Not_Licensed + "<br>" + ZaMsg.INFO_goToLicense);
+                    ZaApp.getInstance().getCurrentController().popupErrorDialog(ZaMsg.ERROR_Feature_Not_Licensed);
                 }
             } else {
                 this._updateHistory(item, true, isShowInHistory);

--- a/WebRoot/js/zimbraAdmin/common/ZaTree.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaTree.js
@@ -524,10 +524,19 @@ function(item, ev) {
 
         this._selectedItems.add(item);
 
-		if (item._setSelected(true)) {
-            this._updateHistory(item, true, isShowInHistory);
-			this._notifyListeners(DwtEvent.SELECTION, [item], DwtTree.ITEM_SELECTED, ev, this._selEv);
-		}
+        if (item._setSelected(true)) {
+            if (item._text === ZaMsg.NAD_Tab_HSM) {
+                if (ZaHSM && ZaHSM.checkstoragefeaturenabled()) {
+                    this._updateHistory(item, true, isShowInHistory);
+                    this._notifyListeners(DwtEvent.SELECTION, [item], DwtTree.ITEM_SELECTED, ev, this._selEv);
+                } else {
+                    ZaApp.getInstance().getCurrentController().popupErrorDialog(ZaMsg.ERROR_Feature_Not_Licensed + "<br>" + ZaMsg.INFO_goToLicense);
+                }
+            } else {
+                this._updateHistory(item, true, isShowInHistory);
+                this._notifyListeners(DwtEvent.SELECTION, [item], DwtTree.ITEM_SELECTED, ev, this._selEv);
+            }
+        }
 	} else {
         var buildDataItem;
         if (!currentDataItem.isLeaf())

--- a/WebRoot/messages/ZaMsg.properties
+++ b/WebRoot/messages/ZaMsg.properties
@@ -2831,3 +2831,4 @@ LBL_zimbraSieveEditHeaderEnabled = Edit header commands:
 LBL_zimbraSieveRejectMailEnabled = Sieve "reject" action:
 NAD_AdminSieveGrouper = Sieve filter rules
 NAD_LegalInterceptGrouper = Legal Intercept
+ERROR_FEATURE_NOT_LICENSED = You are not currently licensed for this feature.<br><br> Please see Configure - Global Settings - License for more information.

--- a/WebRoot/messages/ZaMsg_en_AU.properties
+++ b/WebRoot/messages/ZaMsg_en_AU.properties
@@ -2792,4 +2792,4 @@ ERROR_InvalidRPLifetime = The range must be a positive integer.
 ERROR_RPExists = Policy "{0}" already exists.
 multiple_servers = multiple servers
 ERROR_INVALID_FILE_NAME = Invalid file name. Use browse button to select a valid file.
-ERROR_Feature_Not_Licensed = You are not currently licensed for this feature.<br> Please see Configure -> Global Settings -> License for more information.
+ERROR_FEATURE_NOT_LICENSED = You are not currently licensed for this feature.<br><br> Please see Configure - Global Settings - License for more information.

--- a/WebRoot/messages/ZaMsg_en_AU.properties
+++ b/WebRoot/messages/ZaMsg_en_AU.properties
@@ -2792,3 +2792,5 @@ ERROR_InvalidRPLifetime = The range must be a positive integer.
 ERROR_RPExists = Policy "{0}" already exists.
 multiple_servers = multiple servers
 ERROR_INVALID_FILE_NAME = Invalid file name. Use browse button to select a valid file.
+ERROR_Feature_Not_Licensed = You are not currently not licensed for this feature.
+INFO_goToLicense = Please see Configure -> Global Settings -> License for more information.

--- a/WebRoot/messages/ZaMsg_en_AU.properties
+++ b/WebRoot/messages/ZaMsg_en_AU.properties
@@ -2792,5 +2792,4 @@ ERROR_InvalidRPLifetime = The range must be a positive integer.
 ERROR_RPExists = Policy "{0}" already exists.
 multiple_servers = multiple servers
 ERROR_INVALID_FILE_NAME = Invalid file name. Use browse button to select a valid file.
-ERROR_Feature_Not_Licensed = You are not currently not licensed for this feature.
-INFO_goToLicense = Please see Configure -> Global Settings -> License for more information.
+ERROR_Feature_Not_Licensed = You are not currently licensed for this feature.<br> Please see Configure -> Global Settings -> License for more information.


### PR DESCRIPTION
- Added a check _itemClicked method for storage management which evaluates value of storagemanagement from getlicenseinfo and displays error in case it is false or the Storage management extension is not present as the ZaVolume gets initialised and the internal volumes are displayed in case the extension is not present.