### PR TITLE
ZCS-14347:HSM / S3 restriction based on license status

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/ZaTree.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaTree.js
@@ -525,7 +525,7 @@ function(item, ev) {
         this._selectedItems.add(item);
 
         if (item._setSelected(true)) {
-            if ((item._text === ZaMsg.NAD_Tab_HSM && typeof ZaHSM !== 'undefined' && ZaHSM.checkstoragefeaturenabled()) ||
+            if ((item._text === ZaMsg.NAD_Tab_HSM && typeof ZaHSM !== 'undefined' && ZaHSM.checkStorageFeatureEnabled()) ||
                 item._text !== ZaMsg.NAD_Tab_HSM) {
                 this._updateHistory(item, true, isShowInHistory);
                 this._notifyListeners(DwtEvent.SELECTION, [item], DwtTree.ITEM_SELECTED, ev, this._selEv);

--- a/WebRoot/messages/ZaMsg.properties
+++ b/WebRoot/messages/ZaMsg.properties
@@ -2840,4 +2840,4 @@ LBL_zimbraSieveEditHeaderEnabled = Edit header commands:
 LBL_zimbraSieveRejectMailEnabled = Sieve "reject" action:
 NAD_AdminSieveGrouper = Sieve filter rules
 NAD_LegalInterceptGrouper = Legal Intercept
-ERROR_FEATURE_NOT_LICENSED = You are not currently licensed for this feature.<br><br> Please see Configure - Global Settings - License for more information.
+ERROR_FEATURE_NOT_LICENSED = Your license for this feature has expired or is not valid.<br><br> Please see Configure - Global Settings - License for more information.

--- a/WebRoot/messages/ZaMsg_en_AU.properties
+++ b/WebRoot/messages/ZaMsg_en_AU.properties
@@ -2801,4 +2801,4 @@ ERROR_InvalidRPLifetime = The range must be a positive integer.
 ERROR_RPExists = Policy "{0}" already exists.
 multiple_servers = multiple servers
 ERROR_INVALID_FILE_NAME = Invalid file name. Use browse button to select a valid file.
-ERROR_FEATURE_NOT_LICENSED = You are not currently licensed for this feature.<br><br> Please see Configure - Global Settings - License for more information.
+ERROR_FEATURE_NOT_LICENSED = Your license for this feature has expired or is not valid.<br><br> Please see Configure - Global Settings - License for more information.

--- a/WebRoot/messages/ZaMsg_en_GB.properties
+++ b/WebRoot/messages/ZaMsg_en_GB.properties
@@ -2706,4 +2706,4 @@ ERROR_InvalidRPLifetime = The range must be a positive integer.
 ERROR_RPExists = Policy "{0}" already exists.
 multiple_servers = multiple servers
 ERROR_INVALID_FILE_NAME = Invalid file name. Use browse button to select a valid file.
-ERROR_FEATURE_NOT_LICENSED = You are not currently licensed for this feature.<br><br> Please see Configure - Global Settings - License for more information.
+ERROR_FEATURE_NOT_LICENSED = Your license for this feature has expired or is not valid.<br><br> Please see Configure - Global Settings - License for more information.


### PR DESCRIPTION
- changed the error string ERROR_FEATURE_NOT_LICENSED to Your license for this feature has expired or is not valid. Please see Configure - Global Settings - License for more information.