### PR TITLE
ZCS-15059: add ability to set empty value on multi-value attribute in CreateCosRequest

### DIFF
--- a/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
+++ b/WebRoot/js/zimbraAdmin/cos/model/ZaCos.js
@@ -336,6 +336,9 @@ function (obj) {
     }
 }
 
+// array of attributes to allow an empty value in CreateCosRequest
+ZaCos.attrsEmptyValueAllowed = new Array();
+
 /**
 * public ZaCos.rename
 * @param name - name for the new COS
@@ -360,6 +363,9 @@ function(name, mods) {
 
                     attr.setAttribute("n", aname);
                 }
+            } else if (ZaCos.attrsEmptyValueAllowed.indexOf(aname) != -1) {
+                var attr = soapDoc.set("a", "");
+                attr.setAttribute("n", aname);
             }
         } else if(mods[aname] && (mods[aname].length || !isNaN(mods[aname]) )) {
             var attr = soapDoc.set("a", mods[aname]);


### PR DESCRIPTION
Adding an ability to set empty value on an attribute which can have multiple values (i.e. cardinality="multi") in CreateCosRequest.

**Issue:**
There is a setting which has multiple checkboxes. When all checkbox of an attribute is unchecked, an empty value should be sent at CreateCosRequest (i.e. `<a n=attr_name></a>`). Currently an empty value is not sent, and then a default value of a cos defined in `defaultCOSValue` is used.

**Change:**
* add an array to set attribute name(s)
* add a logic to set an empty value of the attribute included in the array. It works only on an attribute with cardinality="multi" as it is in `if(mods[aname] instanceof Array) {` block