### PR TITLE
ZCS-15293: License | Disable BackupEnabled API, if license/feature is not activated

### DIFF
--- a/WebRoot/js/zimbraAdmin/common/ZaTree.js
+++ b/WebRoot/js/zimbraAdmin/common/ZaTree.js
@@ -506,7 +506,7 @@ function(item, ev) {
     var currentDataItem =  item.getData("dataItem");
     var isShowInHistory = currentDataItem.isShowHistory;
     var isAlias = currentDataItem.isAlias();
-	var isLicensedItem = false;
+    var isLicensedItem = false;
     var isLicenseValid = false;
     for (var i = 0; i < ZaTree.licenseCheckArray.length; i++) {
         if (item._text === ZaTree.licenseCheckArray[i].label) {


### PR DESCRIPTION
In case the license is not valid the license is expired or the Feature attribute is disabled in the license, we have to stop the user from accessing that functionality and have to show an error popup on the item clicked.
- Added a blank array licenseCheckArray.(Passing objects into that array through the admin extensions)
- update the itemClicked function for admin extensions.