### PR TITLE
ZBUG-4153: removed onselectstart from search field

### DIFF
--- a/WebRoot/js/zimbraAdmin/search/view/ZaSearchField.js
+++ b/WebRoot/js/zimbraAdmin/search/view/ZaSearchField.js
@@ -29,6 +29,14 @@ ZaSearchField = function(parent, className, size, posStyle, id) {
 	this._localXForm.setInstance(this._containedObject);
 	this._app = ZaApp.getInstance();
 	this._searchFieldId = id;
+
+	// enable Ctrl+A key
+	var queryXFormItem = this._localXForm.getItemsById(ZaSearch.A_query)[0];
+	var searchFieldDivId = queryXFormItem.getId();
+	var divElement = document.getElementById(searchFieldDivId);
+	if (divElement && divElement.onselectstart) {
+		divElement.onselectstart = null;
+	}
 }
 
 ZaSearchField.prototype = new DwtComposite;


### PR DESCRIPTION
**Issue:**
Ctrl+A key does not work in search field at the top of the page on admin console.

**Root cause:**
`onselectstart` is disabled in a parent div element.
`<div id="_XForm_query" class="dynselect" style="width:100%;" onclick="XFG.cacheGet('_XForm').getItemById('_XForm_query').onClick(event)" onselectstart="return false">`

It is set in the following code:
```
DynSelect_XFormItem.prototype.outputHTML = function (HTMLoutput) {
   //...
    HTMLoutput.append (
        "<div id=",
        id,
        this.getCssString(),
        " onclick=\"",
        this.getFormGlobalRef(),
        ".getItemById('",
        this.getId(),
        "').onClick(event)\"",
        " onselectstart=\"return false\"", <===== HERE
        ">",
        //...
    );
```

**Fix:**
* set `onselectstart` to `null` on the search field.
   * As `DynSelect_XFormItem` form is used not only on the search field but also other forms, the above `HTMLoutput.append` is not modified.

