### PR TITLE
ZBUG-4870: NO_SUCH_ACCOUNT error encountered when attempting to delete a domain with existing account aliases.

### DIFF
--- a/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainListController.js
+++ b/WebRoot/js/zimbraAdmin/domains/controller/ZaDomainListController.js
@@ -576,17 +576,40 @@ function (domainName) {
             busyMsg:ZaMsg.BUSY_SEARCHING
         }
         var resp = ZaSearch.searchDirectory(searchParams);
-        if(resp && resp.Body.SearchDirectoryResponse) {
-            var response = resp.Body.SearchDirectoryResponse;
-            var acctlist = new ZaItemList(ZaAccount);
-            acctlist.loadFromJS(response);
-            return acctlist.getArray();
-        } else return null;
-    } else {
-        var currentController = ZaApp.getInstance().getCurrentController () ;
-        currentController.popupErrorDialog(ZaMsg.ERROR_NO_DOMAIN_NAME) ;
-    }
-    return null;
+		if(resp && resp.Body.SearchDirectoryResponse) {
+			var response = resp.Body.SearchDirectoryResponse;
+			var combinedList = [];
+			// Handle Accounts
+			if (response.account) {
+				var acctlist = new ZaItemList(ZaAccount);
+				acctlist.loadFromJS({ account: response.account });
+				combinedList = combinedList.concat(acctlist.getArray());
+			}
+			// Handle Aliases
+			if (response.alias) {
+				var aliaslist = new ZaItemList(ZaAlias);
+				aliaslist.loadFromJS({ alias: response.alias });
+				combinedList = combinedList.concat(aliaslist.getArray());
+			}
+			// Handle Distribution Lists
+			if (response.dl) {
+				var dllist = new ZaItemList(ZaDistributionList);
+				dllist.loadFromJS({ dl: response.dl });
+				combinedList = combinedList.concat(dllist.getArray());
+			}
+			// Handle Calendar Resources
+			if (response.calresource) {
+				var resourcelist = new ZaItemList(ZaResource);
+				resourcelist.loadFromJS({ calresource: response.calresource });
+				combinedList = combinedList.concat(resourcelist.getArray());
+			}
+			return combinedList;
+		} else return null;
+	} else {
+		var currentController = ZaApp.getInstance().getCurrentController () ;
+		currentController.popupErrorDialog(ZaMsg.ERROR_NO_DOMAIN_NAME) ;
+	}
+	return null;
 }
 
 ZaDomainListController.prototype._forceDeleteDomain =


### PR DESCRIPTION
### Issue
When attempting to delete a domain containing cross-domain aliases, the system incorrectly throws a "NO_SUCH_ACCOUNT" error, preventing legitimate domain deletions.

### Findings
- The original implementation was not distinguishing between accounts and aliases, causing misidentification of cross-domain aliases as accounts
- Other object types (DLs, Calendar Resources) were also not properly handled, potentially leading to incomplete or incorrect search results
- By separating the handling of each object type, we can now correctly process cross-domain aliases without generating false "NO_SUCH_ACCOUNT" errors

### Solution
Modified the `_getAllAccountDomain` method to properly handle different object types in the search response.

Key improvements:
- Implemented separate handling for Account, Alias, Distribution List (DL), and Calendar Resource objects
- Added type-specific `ZaItemList` instantiation for each object type
- Ensured correct data separation in `loadFromJS` calls for each object type
- Implemented clean combination of results from all object types

### Impact
- Resolves the "NO_SUCH_ACCOUNT" error during domain deletion with cross-domain aliases
- Enables proper deletion of domains containing cross-domain aliases
- Ensures correct handling of all object types (Accounts, Aliases, DLs, Resources) during domain searches
- Improves overall accuracy of domain-related operations

### Testing Performed
Tested various scenarios including:
1. Domain deletion with cross-domain aliases
2. Domain operations with multiple object types
3. Verified absence of false "NO_SUCH_ACCOUNT" errors
4. Confirmed proper handling of each object type during search operations
