### PR TITLE
ZBUG-3928: [Admin UI] Fix wrong Polish translations of Active Directory terms

### DIFF
--- a/WebRoot/messages/ZaMsg_pl.properties
+++ b/WebRoot/messages/ZaMsg_pl.properties
@@ -180,7 +180,7 @@ DataIsStale = (dane s\u0105 przestarza\u0142e)
 # Domain configuration labels 
 AuthMech_zimbra = Wewn\u0119trzne
 AuthMech_ldap = Zewn\u0119trzny LDAP
-AuthMech_ad = Zewn\u0119trzny katalog aktywny
+AuthMech_ad = Zewn\u0119trzne Active Directory
 pleaseWaitSearching = Wyszukiwanie. Prosz\u0119 czeka\u0107... 
 pleaseWait = Czekaj...
 searchForDomains = Szukaj domen
@@ -190,7 +190,7 @@ GALMode_external = Zewn\u0119trzne
 GALMode_both = Oba rodzaje
 
 GALServerType_ldap = LDAP
-GALServerType_ad = Aktywny katalog
+GALServerType_ad = Active Directory
 LBL_GALAccount = Konto GAL:
 Domain_GAL_Add = Dodano konto GAL
 Domain_GAL_Remove = Usu\u0144
@@ -703,7 +703,7 @@ Alert_ServerDetails = \
  <b>Uwaga:</b> Ustawienia na pojedynczym serwerze maj\u0105 wy\u017cszy priorytet ni\u017c globalne ustawienia.
 Alert_GlobalConfig = \
     <b>Uwaga:</b> \
-    Ustawienia dotycz\u0105 jedynie serwer\u00f3w, na kt\u00f3rych\
+    Ustawienia dotycz\u0105 jedynie serwer\u00f3w, na kt\u00f3rych \
 s\u0105 zainstalowane i w\u0142\u0105czone odpowiednie us\u0142ugi. Ustawienia zastosowane do serwer\u00f3w, domen i klas us\u0142ug maj\u0105 priorytet nad ustawieniami globalnymi.
 Alert_ServerRestart = \
 	<b>Ostrze\u017cenie:</b> \
@@ -2706,7 +2706,7 @@ stepAuthBindLDAP = Powi\u0105zanie LDAP
 stepAuthSummary = Podsumowanie konfiguracji uwierzytelniania
 stepLDAPAuthSetting = Ustawienia LDAP
 authForDomainMsg = <b>Tryb uwierzytelniania dla tej domeny</b>
-authForADMsg = <b>Aktywne ustawienia ksi\u0105\u017cki adresowej</b>
+authForADMsg = <b>Ustawienia Active Directory</b>
 authForLDAPMsg = <b>Ustawienia zewn\u0119trzne LDAP</b>
 authSummaryMsg = <b>Podsumowanie konfiguracji uwierzytelniania</b>
 authForSpnegoSettingMsg = <b>Ustawienia SPNEGO serwera</b>

--- a/WebRoot/messages/ZmMsg_pl.properties
+++ b/WebRoot/messages/ZmMsg_pl.properties
@@ -649,7 +649,7 @@ clientLoginNotice = <a target="_new" href="https://www.zimbra.com">Zimbra</a>: l
     <a target="_new" href="https://blog.zimbra.com">Blog</a> - \
     <a target="_new" href="https://wiki.zimbra.com">Wiki</a> - \
     <a target="_new" href="https://www.zimbra.com/forums">Fora</a>
-clientMobile = Mobilny
+clientMobile = Urz\u0105dzenia mobilne
 clientPreferred = Domy\u015blny
 clientStandard = Standardowy (HTML)
 clientTouch = Dla urz\u0105dze\u0144 dotykowych
@@ -2106,7 +2106,7 @@ misspelling = b\u0142\u0105d pisowni
 misspellings = b\u0142\u0119dy w pisowni
 misspellingsMessage = Liczba znalezionych b\u0142\u0119d\u00f3w pisowni: {0}. Czy chcesz je poprawi\u0107?
 misspellingsResult = {0,number} {0,choice,0#B\u0142\u0119dy w pisowni|1#B\u0142\u0105d w pisowni|2#B\u0142\u0119dy w pisowni}
-mobile = Mobilny
+mobile = Urz\u0105dzenia mobilne
 mobileDevice = Urz\u0105dzenie
 mobileDeviceId = Identyfikator urz\u0105dzenia
 mobileDevices = Urz\u0105dzenia przeno\u015bne


### PR DESCRIPTION
Three keys incorrectly translated the Microsoft brand name "Active Directory" into Polish ("katalog aktywny" = active directory/catalogue), breaking the meaning and violating brand name preservation rules.

- AuthMech_ad: "Zewnętrzny katalog aktywny" → "Zewnętrzne Active Directory"
- GALServerType_ad: "Aktywny katalog" → "Active Directory"
- authForADMsg: "Aktywne ustawienia książki adresowej" → "Ustawienia Active Directory" (previous translation said "Active Address Book Settings" — completely wrong)